### PR TITLE
feat: Create badge component

### DIFF
--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -17,7 +17,6 @@ export const Playground = Template.bind({});
 
 Playground.args = {
   children: 'Badge text',
-  variant: 'subtle',
   size: 'large',
   color: 'brand',
 };
@@ -41,17 +40,5 @@ export const Colors = () => (
     <Badge color="green">Green</Badge>
     <Badge color="orange">Orange</Badge>
     <Badge color="red">Red</Badge>
-  </HStack>
-);
-
-export const Variants = () => (
-  <HStack>
-    <Badge color="blue">Default</Badge>
-    <Badge variant="solid" color="blue">
-      Solid
-    </Badge>
-    <Badge variant="outline" color="blue">
-      Outline
-    </Badge>
   </HStack>
 );

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -23,12 +23,8 @@ Playground.args = {
 
 export const Sizes = () => (
   <HStack>
-    <Badge size="small" color="red">
-      Small
-    </Badge>
-    <Badge size="large" color="red">
-      Large
-    </Badge>
+    <Badge size="small">Small</Badge>
+    <Badge size="large">Large</Badge>
   </HStack>
 );
 

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+
+import { HStack } from '../Stack';
+import { Badge, BadgeProps } from './Badge';
+
+const meta: Meta = {
+  title: 'Badge',
+  component: Badge,
+};
+
+export default meta;
+
+const Template: Story<BadgeProps> = (args) => <Badge {...args} />;
+
+export const Playground = Template.bind({});
+
+Playground.args = {
+  children: 'Badge text',
+  variant: 'subtle',
+  size: 'large',
+  color: 'brand',
+};
+
+export const Sizes = () => (
+  <HStack>
+    <Badge size="small" color="red">
+      Small
+    </Badge>
+    <Badge size="large" color="red">
+      Large
+    </Badge>
+  </HStack>
+);
+
+export const Colors = () => (
+  <HStack>
+    <Badge color="default">Default</Badge>
+    <Badge color="brand">Brand</Badge>
+    <Badge color="blue">Blue</Badge>
+    <Badge color="green">Green</Badge>
+    <Badge color="orange">Orange</Badge>
+    <Badge color="red">Red</Badge>
+  </HStack>
+);
+
+export const Variants = () => (
+  <HStack>
+    <Badge color="blue">Default</Badge>
+    <Badge variant="solid" color="blue">
+      Solid
+    </Badge>
+    <Badge variant="outline" color="blue">
+      Outline
+    </Badge>
+  </HStack>
+);

--- a/packages/ui/src/components/Badge/Badge.test.tsx
+++ b/packages/ui/src/components/Badge/Badge.test.tsx
@@ -7,28 +7,20 @@ describe('Badge', () => {
   it('renders correctly in large size', () => {
     const text = 'Badge Text';
 
-    render(
-      <Badge data-testid="badge" size="large">
-        {text}
-      </Badge>,
-    );
+    render(<Badge size="large">{text}</Badge>);
 
-    const badge = screen.getByTestId('badge');
+    const badge = screen.getByText(text);
 
     expect(badge).toHaveStyle(largeStyleProps);
-    expect(screen.getByText(text)).toBeVisible();
+    expect(badge).toBeVisible();
   });
 
   it('renders correctly in small size', () => {
     const text = 'Badge Text';
 
-    render(
-      <Badge data-testid="badge" size="small">
-        {text}
-      </Badge>,
-    );
+    render(<Badge size="small">{text}</Badge>);
 
-    const badge = screen.getByTestId('badge');
+    const badge = screen.getByText(text);
 
     expect(badge).toHaveStyle(smallStyleProps);
   });

--- a/packages/ui/src/components/Badge/Badge.test.tsx
+++ b/packages/ui/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Badge, largeStyleProps, smallStyleProps } from './Badge';
+
+describe('Badge', () => {
+  it('renders correctly in large size', () => {
+    const text = 'Badge Text';
+
+    render(
+      <Badge data-testid="badge" size="large">
+        {text}
+      </Badge>,
+    );
+
+    const badge = screen.getByTestId('badge');
+
+    expect(badge).toHaveStyle(largeStyleProps);
+    expect(screen.getByText(text)).toBeVisible();
+  });
+
+  it('renders correctly in small size', () => {
+    const text = 'Badge Text';
+
+    render(
+      <Badge data-testid="badge" size="small">
+        {text}
+      </Badge>,
+    );
+
+    const badge = screen.getByTestId('badge');
+
+    expect(badge).toHaveStyle(smallStyleProps);
+  });
+});

--- a/packages/ui/src/components/Badge/Badge.test.tsx
+++ b/packages/ui/src/components/Badge/Badge.test.tsx
@@ -12,7 +12,7 @@ describe('Badge', () => {
     const badge = screen.getByText(text);
 
     expect(badge).toHaveStyle(largeStyleProps);
-    expect(badge).toBeVisible();
+    expect(badge).toBeInTheDocument();
   });
 
   it('renders correctly in small size', () => {

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -35,7 +35,15 @@ export const Badge = forwardRef<BadgeProps, 'div'>(({ size = 'small', color = 'd
   const sizeProps = size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps };
 
   return (
-    <ChakraBadge size={size} colorScheme={color} ref={ref} fontWeight={500} {...sizeProps} {...props}>
+    <ChakraBadge
+      textTransform="none"
+      size={size}
+      colorScheme={color}
+      ref={ref}
+      fontWeight={500}
+      {...sizeProps}
+      {...props}
+    >
       {children}
     </ChakraBadge>
   );

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -32,15 +32,10 @@ export const largeStyleProps = {
 };
 
 export const Badge = forwardRef<BadgeProps, 'div'>(({ size = 'small', color = 'default', children, ...props }, ref) => {
+  const sizeProps = size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps };
+
   return (
-    <ChakraBadge
-      size={size}
-      colorScheme={color}
-      ref={ref}
-      fontWeight={500}
-      {...(size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps })}
-      {...props}
-    >
+    <ChakraBadge size={size} colorScheme={color} ref={ref} fontWeight={500} {...sizeProps} {...props}>
       {children}
     </ChakraBadge>
   );

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -32,13 +32,14 @@ export const largeStyleProps = {
 };
 
 export const Badge = forwardRef<BadgeProps, 'div'>(({ size = 'small', color = 'default', children, ...props }, ref) => {
-  const sizeProps = size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps };
+  const sizeProps = size === 'small' ? smallStyleProps : largeStyleProps;
+  const colorScheme = color === 'default' ? 'gray' : color;
 
   return (
     <ChakraBadge
       textTransform="none"
       size={size}
-      colorScheme={color}
+      colorScheme={colorScheme}
       ref={ref}
       fontWeight={500}
       {...sizeProps}

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,7 +1,5 @@
 import React, { ReactText } from 'react';
-import { Badge as ChakraBadge, BadgeProps as ChakraBadgeProps, forwardRef, HTMLChakraProps } from '@chakra-ui/react';
-
-type BadgeVariant = 'solid' | 'outline' | 'subtle';
+import { Badge as ChakraBadge, forwardRef, HTMLChakraProps } from '@chakra-ui/react';
 
 type BadgeSize = 'small' | 'large';
 
@@ -10,10 +8,6 @@ type BadgeColor = 'default' | 'brand' | 'blue' | 'green' | 'orange' | 'red';
 export interface BadgeProps extends HTMLChakraProps<'div'> {
   children: ReactText | ReactText[];
   /**
-   * Style variant of the badge
-   */
-  variant?: BadgeVariant;
-  /**
    * Color variant of the badge
    */
   color?: BadgeColor;
@@ -21,7 +15,6 @@ export interface BadgeProps extends HTMLChakraProps<'div'> {
    * Determines badge's paddings, font size, line height and border radius.
    */
   size?: BadgeSize;
-  onClick?: ChakraBadgeProps['onClick'];
 }
 
 export const smallStyleProps = {
@@ -38,20 +31,17 @@ export const largeStyleProps = {
   fontSize: '14px',
 };
 
-export const Badge = forwardRef<BadgeProps, 'div'>(
-  ({ variant = 'subtle', size = 'small', color = 'default', children, ...props }, ref) => {
-    return (
-      <ChakraBadge
-        variant={variant}
-        size={size}
-        colorScheme={color}
-        ref={ref}
-        fontWeight={500}
-        {...(size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps })}
-        {...props}
-      >
-        {children}
-      </ChakraBadge>
-    );
-  },
-);
+export const Badge = forwardRef<BadgeProps, 'div'>(({ size = 'small', color = 'default', children, ...props }, ref) => {
+  return (
+    <ChakraBadge
+      size={size}
+      colorScheme={color}
+      ref={ref}
+      fontWeight={500}
+      {...(size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps })}
+      {...props}
+    >
+      {children}
+    </ChakraBadge>
+  );
+});

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,0 +1,57 @@
+import React, { ReactText } from 'react';
+import { Badge as ChakraBadge, BadgeProps as ChakraBadgeProps, forwardRef, HTMLChakraProps } from '@chakra-ui/react';
+
+type BadgeVariant = 'solid' | 'outline' | 'subtle';
+
+type BadgeSize = 'small' | 'large';
+
+type BadgeColor = 'default' | 'brand' | 'blue' | 'green' | 'orange' | 'red';
+
+export interface BadgeProps extends HTMLChakraProps<'div'> {
+  children: ReactText | ReactText[];
+  /**
+   * Style variant of the badge
+   */
+  variant?: BadgeVariant;
+  /**
+   * Color variant of the badge
+   */
+  color?: BadgeColor;
+  /**
+   * Determines badge's paddings, font size, line height and border radius.
+   */
+  size?: BadgeSize;
+  onClick?: ChakraBadgeProps['onClick'];
+}
+
+export const smallStyleProps = {
+  padding: '2px 10px',
+  borderRadius: '10px',
+  lineHeight: '16px',
+  fontSize: '12px',
+};
+
+export const largeStyleProps = {
+  padding: '2px 12px',
+  borderRadius: '12px',
+  lineHeight: '20px',
+  fontSize: '14px',
+};
+
+export const Badge = forwardRef<BadgeProps, 'div'>(
+  ({ variant = 'subtle', size = 'small', color = 'default', children, ...props }, ref) => {
+    return (
+      <ChakraBadge
+        variant={variant}
+        size={size}
+        colorScheme={color}
+        ref={ref}
+        fontWeight={500}
+        {...(size === 'small' ? { ...smallStyleProps } : { ...largeStyleProps })}
+        {...props}
+      >
+        {children}
+      </ChakraBadge>
+    );
+  },
+);

--- a/packages/ui/src/components/Badge/index.ts
+++ b/packages/ui/src/components/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge';
+export type { BadgeProps } from './Badge';


### PR DESCRIPTION
- Main badge configuartion:
  - size: large or small
  - colors: each one matches mockups
  - variants: default, solid, or outlined (The default one matches mockups. Rest wasn't included in them, but I've decided to leave it anyway, just in case we need them in the future)
- PR also contains stories with playground and some basic tests

Closes #11