### PR TITLE
chore(core): add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Dependencies
 node_modules
+package-lock.json
 
 # Production
 dist


### PR DESCRIPTION
As we use Yarn in our project, there is no need to have package-lock.json generated in our repository.