### PR TITLE
chore(core): add code padding rules to ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'prettier',
     'simple-import-sort',
     'testing-library',
+    'jest-formatting',
   ],
   extends: [
     'eslint:recommended',
@@ -106,6 +107,22 @@ module.exports = {
         ],
       },
     ],
+
+    // Add blank lines between particular parts of the code.
+    'padding-line-between-statements': [
+      2,
+      // Always require blank lines before return statements.
+      { blankLine: 'always', prev: '*', next: 'return' },
+
+      // Always require blank lines before and after class declaration, if, switch, try.
+      { blankLine: 'always', prev: '*', next: ['if', 'class', 'for', 'switch', 'try'] },
+      { blankLine: 'always', prev: ['if', 'class', 'for', 'switch', 'try'], next: '*' },
+
+      // Always require blank lines before and after every sequence of variable declarations and export.
+      { blankLine: 'always', prev: '*', next: ['const', 'let', 'var', 'export'] },
+      { blankLine: 'always', prev: ['const', 'let', 'var', 'export'], next: '*' },
+      { blankLine: 'any', prev: ['const', 'let', 'var', 'export'], next: ['const', 'let', 'var', 'export'] },
+    ],
   },
   overrides: [
     {
@@ -137,14 +154,19 @@ module.exports = {
       rules: { '@typescript-eslint/no-var-requires': 0 },
     },
     {
-      // Files that should to contain a default export.
+      // Files that should contain a default export.
       files: ['*.config.[tj]s', 'packages/website/pages/**/*.tsx', '*.stories.tsx'],
       rules: { 'import/no-default-export': 0 },
     },
     {
-      // Enable plugins rules only for test files
+      // Enable plugins rules only for test files.
       files: ['**/?(*.)+(spec|test).ts?(x)'],
-      extends: ['plugin:testing-library/react', 'plugin:jest-dom/recommended', 'plugin:jest/recommended'],
+      extends: [
+        'plugin:testing-library/react',
+        'plugin:jest-dom/recommended',
+        'plugin:jest/recommended',
+        'plugin:jest-formatting/recommended',
+      ],
     },
   ],
   settings: {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-jest": "24.4.0",
     "eslint-plugin-jest-dom": "3.9.0",
+    "eslint-plugin-jest-formatting": "3.0.0",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "eslint-plugin-react": "7.24.0",

--- a/packages/api/src/auth/github/github.client.ts
+++ b/packages/api/src/auth/github/github.client.ts
@@ -32,9 +32,11 @@ export class GithubClient extends GithubStrategy(Strategy) {
 
   async githubAuth(user: GithubUserData): Promise<{ accessToken: string; profile: UserDTO } | null> {
     let userFromDatabase = await this.usersRepository.getByGithubId(user.githubId);
+
     if (!userFromDatabase) {
       userFromDatabase = await this.usersRepository.create(user);
     }
+
     return userFromDatabase
       ? {
           accessToken: this.jwtStrategy.generateToken(userFromDatabase),

--- a/packages/api/src/auth/github/github.controller.ts
+++ b/packages/api/src/auth/github/github.controller.ts
@@ -20,6 +20,7 @@ export class GithubController {
     const result = await this.githubClient.githubAuth(req.user);
 
     if (result) return result;
+
     throw new InternalServerErrorException();
   }
 }

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -6,6 +6,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.setGlobalPrefix('api');
   await app.listen(env.PORT);
 }

--- a/packages/api/src/users/users.mapper.ts
+++ b/packages/api/src/users/users.mapper.ts
@@ -13,6 +13,7 @@ export class UsersMapper {
 
   static fromGithubInputToDomain(value: GithubDTO): Omit<User, 'id'> {
     const { email, id, avatar_url: image, name } = value;
+
     return {
       email,
       githubId: id,

--- a/packages/panel/src/hooks/useUsers.ts
+++ b/packages/panel/src/hooks/useUsers.ts
@@ -6,6 +6,7 @@ export const useUsers = () => {
   const state = useAsync(async () => {
     const response = await fetch('/api/users');
     const result: GetAllUsersResponse = await response.json();
+
     return result;
   }, []);
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -45,6 +45,7 @@ export interface ButtonProps extends HTMLChakraProps<'button'> {
 
 const getSchemeFromColor = (color: ButtonColor): ChakraButtonProps['colorScheme'] => {
   if (color === 'danger') return 'red';
+
   if (color === 'brand') return 'brand';
 
   return 'gray';

--- a/packages/ui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.test.tsx
@@ -11,6 +11,7 @@ describe('Checkbox component', () => {
 
     expect(checkbox).toBeInTheDocument();
   });
+
   it('checks that checked checkbox is checked', () => {
     render(<Checkbox value="test" onChange={() => {}} checked aria-label="checkbox" />);
 
@@ -18,8 +19,10 @@ describe('Checkbox component', () => {
 
     expect(checkbox).toBeChecked();
   });
+
   it('checks checkbox displays correct labels', () => {
     const label = 'checkbox name';
+
     render(
       <Checkbox value="test" onChange={() => {}} checked>
         {label}

--- a/packages/ui/src/components/Input/Input.test.tsx
+++ b/packages/ui/src/components/Input/Input.test.tsx
@@ -11,10 +11,12 @@ describe('Input', () => {
     expect(getInput()).toBeEnabled();
     expect(getInput()).toBeInTheDocument();
   });
+
   it('render correctly in disabled state', () => {
     render(<Input disabled data-testid="input" />);
     expect(getInput()).toBeDisabled();
   });
+
   it('render correctly in invalid state', () => {
     render(<Input isInvalid="true" data-testid="input" />);
     expect(getInput()).toBeInvalid();

--- a/packages/ui/src/components/Label/Label.test.tsx
+++ b/packages/ui/src/components/Label/Label.test.tsx
@@ -4,12 +4,14 @@ import { render, screen } from '@testing-library/react';
 import { Label } from './Label';
 
 const text = 'Label';
+
 describe('Label', () => {
   it('renders correctly', () => {
     render(<Label size="md">{text}</Label>);
 
     expect(screen.getByText(text)).toBeInTheDocument();
   });
+
   it('should display asterisk when required props is true', () => {
     render(
       <Label size="md" required>

--- a/packages/ui/src/components/Logo/Logo.test.tsx
+++ b/packages/ui/src/components/Logo/Logo.test.tsx
@@ -8,6 +8,7 @@ describe('Logo', () => {
     render(<Logo />);
 
     const logo = screen.getByRole('img');
+
     expect(logo).toHaveAttribute('alt', 'Logo CodersCamp');
   });
 });

--- a/packages/ui/src/components/Textarea/Textarea.test.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.test.tsx
@@ -10,11 +10,13 @@ describe('Textarea', () => {
     render(<Textarea disabled />);
     expect(getTextarea()).toBeDisabled();
   });
+
   it('Renders correctly as default textarea', () => {
     render(<Textarea />);
     expect(getTextarea()).toBeEnabled();
     expect(getTextarea()).toBeInTheDocument();
   });
+
   it('Renders correctly in invalid state', () => {
     render(<Textarea invalid />);
     expect(getTextarea()).toBeInvalid();

--- a/packages/ui/src/components/Typography/Typography.test.tsx
+++ b/packages/ui/src/components/Typography/Typography.test.tsx
@@ -6,18 +6,25 @@ import { Typography } from './Typography';
 describe('Typography', () => {
   it('test component render properly', () => {
     const text = 'Lorem ipsum';
+
     render(<Typography size="xl">{text}</Typography>);
+
     const typography = screen.getByText(text);
+
     expect(typography).toBeInTheDocument();
   });
+
   it('should have styles "textDecoration=underline "and "color=brand.500" when receive "as" props equal to "a"', () => {
     const text = 'Lorem ipsum';
+
     render(
       <Typography size="xl" as="a" href="#">
         {text}
       </Typography>,
     );
+
     const typography = screen.getByText(text);
+
     expect(typography).toHaveStyle({
       textDecoration: 'underline',
       color: 'brand.500',

--- a/packages/ui/src/components/Typography/Typography.tsx
+++ b/packages/ui/src/components/Typography/Typography.tsx
@@ -26,6 +26,7 @@ const anchorStyle = {
 export const Typography = forwardRef<TypographyProps, 'div'>(
   ({ as = 'div', size = 'md', weight = 'regular', children, ...props }, ref) => {
     const stylesForLink = as === 'a' && anchorStyle;
+
     return (
       <Box as={as} fontSize={size} ref={ref} fontWeight={weight} {...props} {...stylesForLink}>
         {children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9705,6 +9705,7 @@ __metadata:
     eslint-plugin-import: 2.23.4
     eslint-plugin-jest: 24.4.0
     eslint-plugin-jest-dom: 3.9.0
+    eslint-plugin-jest-formatting: 3.0.0
     eslint-plugin-jsx-a11y: 6.4.1
     eslint-plugin-prettier: 3.4.0
     eslint-plugin-react: 7.24.0
@@ -11978,6 +11979,15 @@ __metadata:
   peerDependencies:
     eslint: ">=6.8"
   checksum: 194129c5fd4e04b979aedaa180d5f9f2eab23015d46a3be945c179c72912586827311fe78398cdb4dc3d488a55b34ab8240e8f3ede6092efd313a7a987399be3
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jest-formatting@npm:3.0.0":
+  version: 3.0.0
+  resolution: "eslint-plugin-jest-formatting@npm:3.0.0"
+  peerDependencies:
+    eslint: ">=0.8.0"
+  checksum: 2037d6d9602a4e072f29d7236395667b2ede6268d58907bce7f5751b0b7ed3cb361c7c35795a99a8a9d76ecb3f5ed5e6043e0a9d9b3e4dff5c4a03fb68153925
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This commits adds new ESLint rules related to padding (blank lines) between different code elements. It should improve our code consistency when it comes to spacing and reduce the number of nitpicks related to this topic.

All rules can be fixed automatically so if you have your IDE configured correctly to handle ESLint there would be no additional effort on your side when writing the code.