### PR TITLE
ci: add regex to PR title check to enforce conventional commits naming

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,6 +21,7 @@ jobs:
             deps
           requireScope: false
           validateSingleCommit: true
+          subjectPattern: ^(?![A-Z]).+$
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
As we want to follow [Conventional Commits guidelines](https://www.conventionalcommits.org/en/v1.0.0/) I added an additional check to our CI to ensure all PR titles start with a small letter