### PR TITLE
build(website): disable TS types checking during the Next.js build

### DIFF
--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -15,4 +15,7 @@ module.exports = withPlugins([withTranspileModules(monorepoPackageNames), withIm
   eslint: {
     ignoreDuringBuilds: true,
   },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 });


### PR DESCRIPTION
As we have a separate CI job to check if all TS types are correct it seems unnecessary to do type-checking the second time during the Next.js build process.