### PR TITLE
fix(ui): export sample theme to fix theme typings generation

### DIFF
--- a/packages/ui/src/theme/overwrites/index.ts
+++ b/packages/ui/src/theme/overwrites/index.ts
@@ -15,3 +15,6 @@ export const createTheme = (globalStyles: Styles['global']) =>
       useSystemColorMode: false,
     },
   });
+
+// eslint-disable-next-line import/no-default-export
+export default createTheme({});


### PR DESCRIPTION
Chakra UI CLI needs a default export (or a named export called `theme`) of the theme object to generate typings. As we changed our `theme` constant export to `createTheme` function we need to export the sample theme as the default one, so the CLI can work properly.