### PR TITLE
refactor(api): convert all model IDs from number to uuid

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,8 +14,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config jest-e2e.config.ts",
     "generate": "prisma generate",
-    "synchronize": "prisma db push",
-    "migrate": "prisma migrate dev"
+    "db:sync": "prisma db push",
+    "db:migrate": "prisma migrate dev",
+    "db:reset": "prisma migrate reset"
   },
   "dependencies": {
     "@coderscamp/shared": "0.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,8 @@
     "passport-jwt": "4.0.0",
     "puppeteer": "10.2.0",
     "reflect-metadata": "0.1.13",
-    "rxjs": "7.3.0"
+    "rxjs": "7.3.0",
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@nestjs/cli": "8.1.1",
@@ -50,6 +51,7 @@
     "@types/passport-github2": "1.2.5",
     "@types/passport-jwt": "3.0.6",
     "@types/supertest": "2.0.11",
+    "@types/uuid": "8.3.1",
     "node-mocks-http": "1.10.1",
     "prisma": "2.29.0",
     "supertest": "6.1.5",

--- a/packages/api/prisma/migrations/20210818161746_id_as_strings/migration.sql
+++ b/packages/api/prisma/migrations/20210818161746_id_as_strings/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - The primary key for the `LearningMaterial` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "LearningMaterial" DROP CONSTRAINT "LearningMaterial_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "userId" SET DATA TYPE TEXT,
+ADD PRIMARY KEY ("id");
+DROP SEQUENCE "LearningMaterial_id_seq";
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD PRIMARY KEY ("id");
+DROP SEQUENCE "User_id_seq";

--- a/packages/api/prisma/migrations/20210818212958_native_uuid/migration.sql
+++ b/packages/api/prisma/migrations/20210818212958_native_uuid/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - The primary key for the `LearningMaterial` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `LearningMaterial` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - A unique constraint covering the columns `[userId]` on the table `LearningMaterial` will be added. If there are existing duplicate values, this will fail.
+  - Changed the type of `userId` on the `LearningMaterial` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "LearningMaterial" DROP CONSTRAINT "LearningMaterial_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+DROP COLUMN "userId",
+ADD COLUMN     "userId" UUID NOT NULL,
+ADD PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+ADD PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LearningMaterial.userId_unique" ON "LearningMaterial"("userId");

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 }
 
 model User {
-  id       String @id @default(uuid())
+  id       String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   githubId Int    @unique
   fullName String
   email    String
@@ -16,8 +16,8 @@ model User {
 }
 
 model LearningMaterial {
-  id             String @id @default(uuid())
+  id             String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   url            String
   completedCount Int    @default(0)
-  userId         String @unique
+  userId         String @unique @db.Uuid
 }

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 }
 
 model User {
-  id       Int    @id @default(autoincrement())
+  id       String @id @default(uuid())
   githubId Int    @unique
   fullName String
   email    String
@@ -16,8 +16,8 @@ model User {
 }
 
 model LearningMaterial {
-  id             Int    @id @default(autoincrement())
+  id             String @id @default(uuid())
   url            String
   completedCount Int    @default(0)
-  userId         Int    @unique
+  userId         String @unique
 }

--- a/packages/api/src/auth/github/github.controller.spec.ts
+++ b/packages/api/src/auth/github/github.controller.spec.ts
@@ -4,13 +4,14 @@ import httpMocks from 'node-mocks-http';
 
 import { env } from '@/common/env';
 
+import { UserId } from '../../users/users.types';
 import { JwtService } from '../jwt/jwt.service';
 import { GithubController } from './github.controller';
 import { GithubService } from './github.service';
 import { GithubAuthGuardReq } from './github.types';
 
 const user = {
-  id: 1,
+  id: '1',
   fullName: 'Name',
   githubId: 123,
   email: 'example@test.com',
@@ -37,7 +38,7 @@ describe('Github controller', () => {
       authorizeUser: () => Promise.resolve(user),
     };
     jwtService = {
-      generateToken: (_user: { id: number }) => tokenValue,
+      generateToken: (_user: { id: UserId }) => tokenValue,
     };
 
     const module = await Test.createTestingModule({

--- a/packages/api/src/auth/github/github.controller.spec.ts
+++ b/packages/api/src/auth/github/github.controller.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { Test } from '@nestjs/testing';
 import httpMocks from 'node-mocks-http';
+import { v4 as uuidv4 } from 'uuid';
 
 import { env } from '@/common/env';
 
@@ -11,7 +12,7 @@ import { GithubService } from './github.service';
 import { GithubAuthGuardReq } from './github.types';
 
 const user = {
-  id: '1',
+  id: uuidv4(),
   fullName: 'Name',
   githubId: 123,
   email: 'example@test.com',

--- a/packages/api/src/auth/github/github.service.spec.ts
+++ b/packages/api/src/auth/github/github.service.spec.ts
@@ -6,9 +6,10 @@ import { createObjectMock } from '@coderscamp/shared/utils/test';
 import { UsersService } from '../../users/users.service';
 import { UserFromGithub } from '../../users/users.types';
 import { GithubService } from './github.service';
+import type { GithubId } from './github.types';
 
-const createUser = (githubId: number): User => ({
-  id: Math.round(Math.random() * 100),
+const createUser = (githubId: GithubId): User => ({
+  id: String(Math.round(Math.random() * 100)),
   fullName: 'Name',
   githubId,
   email: 'example@test.com',

--- a/packages/api/src/auth/github/github.service.spec.ts
+++ b/packages/api/src/auth/github/github.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test } from '@nestjs/testing';
+import { v4 as uuidv4 } from 'uuid';
 
 import type { User } from '@coderscamp/shared/models/user';
 import { createObjectMock } from '@coderscamp/shared/utils/test';
@@ -9,7 +10,7 @@ import { GithubService } from './github.service';
 import type { GithubId } from './github.types';
 
 const createUser = (githubId: GithubId): User => ({
-  id: String(Math.round(Math.random() * 100)),
+  id: uuidv4(),
   fullName: 'Name',
   githubId,
   email: 'example@test.com',

--- a/packages/api/src/auth/github/github.service.spec.ts
+++ b/packages/api/src/auth/github/github.service.spec.ts
@@ -7,9 +7,9 @@ import { createObjectMock } from '@coderscamp/shared/utils/test';
 import { UsersService } from '../../users/users.service';
 import { UserFromGithub } from '../../users/users.types';
 import { GithubService } from './github.service';
-import type { GithubId } from './github.types';
+import type { GithubUserId } from './github.types';
 
-const createUser = (githubId: GithubId): User => ({
+const createUser = (githubId: GithubUserId): User => ({
   id: uuidv4(),
   fullName: 'Name',
   githubId,

--- a/packages/api/src/auth/github/github.types.ts
+++ b/packages/api/src/auth/github/github.types.ts
@@ -2,10 +2,10 @@ import type { Request } from 'express';
 
 import type { GithubStrategy } from './github.strategy';
 
-export type GithubId = number;
+export type GithubUserId = number;
 
 export interface GithubUser {
-  id: GithubId;
+  id: GithubUserId;
   name: string;
   email: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/api/src/auth/github/github.types.ts
+++ b/packages/api/src/auth/github/github.types.ts
@@ -2,8 +2,10 @@ import type { Request } from 'express';
 
 import type { GithubStrategy } from './github.strategy';
 
+export type GithubId = number;
+
 export interface GithubUser {
-  id: number;
+  id: GithubId;
   name: string;
   email: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/api/src/auth/jwt/jwt-user-id.decorator.ts
+++ b/packages/api/src/auth/jwt/jwt-user-id.decorator.ts
@@ -6,7 +6,7 @@ import type { JwtAuthGuardReq } from './jwt.types';
  * Returns id of the authorized user.
  * @type param decorator
  */
-export const UserId = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+export const JwtUserId = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest<JwtAuthGuardReq>();
 
   return request.user.id;

--- a/packages/api/src/learning-materials/adapters/users.adapter.ts
+++ b/packages/api/src/learning-materials/adapters/users.adapter.ts
@@ -1,13 +1,14 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { UsersService } from '../../users/users.service';
+import type { UserId } from '../../users/users.types';
 import type { UsersPort } from '../ports/users.port';
 
 @Injectable()
 export class UsersAdapter implements UsersPort {
   constructor(private readonly usersService: UsersService) {}
 
-  async getUserFullNameById(userId: number): Promise<string> {
+  async getUserFullNameById(userId: UserId): Promise<string> {
     const user = await this.usersService.getById(userId);
 
     if (!user) {

--- a/packages/api/src/learning-materials/learning-materials.controller.ts
+++ b/packages/api/src/learning-materials/learning-materials.controller.ts
@@ -6,7 +6,8 @@ import type {
 } from '@coderscamp/shared/models/learning-material';
 
 import { JwtAuthGuard } from '../auth/jwt/jwt-auth.guard';
-import { UserId } from '../auth/jwt/user-id.decorator';
+import { JwtUserId } from '../auth/jwt/jwt-user-id.decorator';
+import type { UserId } from '../users/users.types';
 import { LearningMaterialsService } from './learning-materials.service';
 
 @UseGuards(JwtAuthGuard)
@@ -15,12 +16,12 @@ export class LearningMaterialsController {
   constructor(private readonly learningMaterialsService: LearningMaterialsService) {}
 
   @Get()
-  getLearningMaterial(@UserId() userId: number): Promise<GetLearningMaterialResponse> {
+  getLearningMaterial(@JwtUserId() userId: UserId): Promise<GetLearningMaterialResponse> {
     return this.learningMaterialsService.getLearningMaterialByUserId(userId);
   }
 
   @Post()
-  createLearningMaterial(@UserId() userId: number): Promise<CreateLearningMaterialResponse> {
+  createLearningMaterial(@JwtUserId() userId: UserId): Promise<CreateLearningMaterialResponse> {
     return this.learningMaterialsService.createLearningMaterial(userId);
   }
 }

--- a/packages/api/src/learning-materials/learning-materials.service.ts
+++ b/packages/api/src/learning-materials/learning-materials.service.ts
@@ -1,6 +1,7 @@
 import { ConflictException, Inject, Injectable } from '@nestjs/common';
 import { LearningMaterial } from '@prisma/client';
 
+import type { UserId } from '../users/users.types';
 import { LearningMaterialsRepository } from './learning-materials.repository';
 import { generateProcessStChecklist } from './learning-materials.utils';
 import { USERS_PORT, UsersPort } from './ports/users.port';
@@ -12,7 +13,7 @@ export class LearningMaterialsService {
     @Inject(USERS_PORT) private readonly usersPort: UsersPort,
   ) {}
 
-  async createLearningMaterial(userId: number): Promise<LearningMaterial> {
+  async createLearningMaterial(userId: UserId): Promise<LearningMaterial> {
     const userName = await this.usersPort.getUserFullNameById(userId);
     const currentLearningMaterials = await this.learningMaterialsRepository.findUnique({ where: { userId } });
 
@@ -25,7 +26,7 @@ export class LearningMaterialsService {
     return this.learningMaterialsRepository.create({ data: { userId, url } });
   }
 
-  async getLearningMaterialByUserId(userId: number): Promise<LearningMaterial | null> {
+  async getLearningMaterialByUserId(userId: UserId): Promise<LearningMaterial | null> {
     return this.learningMaterialsRepository.findUnique({ where: { userId } });
   }
 }

--- a/packages/api/src/learning-materials/ports/users.port.ts
+++ b/packages/api/src/learning-materials/ports/users.port.ts
@@ -1,5 +1,7 @@
+import type { UserId } from '../../users/users.types';
+
 export const USERS_PORT = Symbol('USERS_PORT');
 
 export interface UsersPort {
-  getUserFullNameById(userId: number): Promise<string>;
+  getUserFullNameById(userId: UserId): Promise<string>;
 }

--- a/packages/api/src/users/users.controller.ts
+++ b/packages/api/src/users/users.controller.ts
@@ -3,8 +3,9 @@ import { Controller, Get, UseGuards } from '@nestjs/common';
 import type { GetAllUsersResponse, GetMeResponse } from '@coderscamp/shared/models/user';
 
 import { JwtAuthGuard } from '../auth/jwt/jwt-auth.guard';
-import { UserId } from '../auth/jwt/user-id.decorator';
+import { JwtUserId } from '../auth/jwt/jwt-user-id.decorator';
 import { UsersService } from './users.service';
+import type { UserId } from './users.types';
 
 @Controller('users')
 export class UsersController {
@@ -17,7 +18,7 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Get('/me')
-  async getMe(@UserId() id: number): Promise<GetMeResponse> {
+  async getMe(@JwtUserId() id: UserId): Promise<GetMeResponse> {
     return this.usersService.getById(id);
   }
 }

--- a/packages/api/src/users/users.mapper.ts
+++ b/packages/api/src/users/users.mapper.ts
@@ -14,13 +14,13 @@ export class UsersMapper {
 
   static fromJwtToDomain(payload: JwtPayload): UserFromJwt {
     return {
-      id: Number(payload.sub),
+      id: payload.sub,
     };
   }
 
   static fromDomainToJwt(user: UserFromJwt): JwtPayload {
     return {
-      sub: String(user.id),
+      sub: user.id,
     };
   }
 }

--- a/packages/api/src/users/users.service.ts
+++ b/packages/api/src/users/users.service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import type { GithubId } from 'src/auth/github/github.types';
 
 import type { User } from '@coderscamp/shared/models/user';
 
 import { UsersRepository } from './users.repository';
+import type { UserId } from './users.types';
 
 @Injectable()
 export class UsersService {
@@ -16,11 +18,11 @@ export class UsersService {
     return this.usersRepository.create({ data: userData });
   }
 
-  getById(id: number): Promise<User | null> {
+  getById(id: UserId): Promise<User | null> {
     return this.usersRepository.findUnique({ where: { id } });
   }
 
-  getByGithubId(githubId: number): Promise<User | null> {
+  getByGithubId(githubId: GithubId): Promise<User | null> {
     return this.usersRepository.findUnique({ where: { githubId } });
   }
 }

--- a/packages/api/src/users/users.service.ts
+++ b/packages/api/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import type { GithubId } from 'src/auth/github/github.types';
+import type { GithubUserId } from 'src/auth/github/github.types';
 
 import type { User } from '@coderscamp/shared/models/user';
 
@@ -22,7 +22,7 @@ export class UsersService {
     return this.usersRepository.findUnique({ where: { id } });
   }
 
-  getByGithubId(githubId: GithubId): Promise<User | null> {
+  getByGithubId(githubId: GithubUserId): Promise<User | null> {
     return this.usersRepository.findUnique({ where: { githubId } });
   }
 }

--- a/packages/api/src/users/users.types.ts
+++ b/packages/api/src/users/users.types.ts
@@ -3,3 +3,5 @@ import { User } from '@coderscamp/shared/models/user';
 export type UserFromGithub = Pick<User, 'fullName' | 'githubId' | 'email' | 'image'>;
 
 export type UserFromJwt = Pick<User, 'id'>;
+
+export type UserId = string;

--- a/packages/shared/src/models/learning-material.ts
+++ b/packages/shared/src/models/learning-material.ts
@@ -1,8 +1,8 @@
 export interface LearningMaterial {
-  id: number;
+  id: string;
   url: string;
   completedCount: number;
-  userId: number;
+  userId: string;
 }
 
 export type CreateLearningMaterialResponse = LearningMaterial;

--- a/packages/shared/src/models/user.ts
+++ b/packages/shared/src/models/user.ts
@@ -1,5 +1,5 @@
 export type User = {
-  id: number;
+  id: string;
   githubId: number;
   fullName: string;
   email: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,6 +2684,7 @@ __metadata:
     "@types/passport-github2": 1.2.5
     "@types/passport-jwt": 3.0.6
     "@types/supertest": 2.0.11
+    "@types/uuid": 8.3.1
     cookie-parser: 1.4.5
     dotenv: 10.0.0
     express: 4.17.1
@@ -2699,6 +2700,7 @@ __metadata:
     ts-loader: 9.2.5
     ts-node: 10.2.0
     tsconfig-paths: 3.10.1
+    uuid: 8.3.2
   languageName: unknown
   linkType: soft
 
@@ -6494,6 +6496,13 @@ __metadata:
   version: 2.0.6
   resolution: "@types/unist@npm:2.0.6"
   checksum: 25cb860ff10dde48b54622d58b23e66214211a61c84c0f15f88d38b61aa1b53d4d46e42b557924a93178c501c166aa37e28d7f6d994aba13d24685326272d5db
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:8.3.1":
+  version: 8.3.1
+  resolution: "@types/uuid@npm:8.3.1"
+  checksum: b41bdc5e86c6f0f1899306be10455636da0f2168c9489b869edd6837ddeb7c0e501b1ff7d857402462986bada2a379125743dd895fa801d03437cd632116a373
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We want to change the default ID type from sequence number to UUID as it would give us the following benefits:
-  we can generate id's anywhere (in other modules, on the frontend),
- we can use them in URLs without exposing the information about your data,
- it would make the app more future-proof (easier to scale or separate into smaller services).