### PR TITLE
ci(core): add TS paths resolution to the core Jest config file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ const FILES_WITH_DEV_DEPENDENCIES = [
   '**/*.spec.*',
   '**/vite.config.ts',
   '**/next.config.js',
+  'jest.config.ts',
   '**/*.stories.tsx',
   '**/setupTests.ts',
   'scripts/*.js',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,30 +1,36 @@
 import type { Config } from '@jest/types';
+import { pathsToModuleNameMapper } from 'ts-jest/utils';
 
 type JestConfig = Config.InitialOptions;
 
 type Options = {
   tsconfig: string;
-  moduleNameMapper?: Record<string, string>;
+  paths?: Record<string, string[]>;
   overrides?: JestConfig;
 };
 
-export const createJestConfig = ({ tsconfig, moduleNameMapper = {}, overrides = {} }: Options): JestConfig => ({
-  moduleFileExtensions: ['js', 'ts', 'tsx', 'json'],
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],
-  moduleNameMapper: {
-    '^@coderscamp/([a-z-]+)/(.+)': '<rootDir>/../$1/src/$2',
-    ...moduleNameMapper,
-  },
-  transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
-    '^.+\\.(svg|css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
-  },
-  globals: {
-    'ts-jest': {
-      tsconfig,
-      isolatedModules: true,
+export const createJestConfig = ({ tsconfig, paths = {}, overrides = {} }: Options): JestConfig => {
+  const pathsMap = pathsToModuleNameMapper(paths) as Record<string, string>;
+  const moduleNameMapper = Object.keys(pathsMap).reduce<Record<string, string>>(
+    (acc, key) => ({ ...acc, [key]: `<rootDir>/${pathsMap[key]}` }),
+    {},
+  );
+
+  return {
+    moduleFileExtensions: ['js', 'ts', 'tsx', 'json'],
+    roots: ['<rootDir>/src'],
+    testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],
+    moduleNameMapper,
+    transform: {
+      '^.+\\.(ts|tsx)$': 'ts-jest',
+      '^.+\\.(svg|css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
     },
-  },
-  ...overrides,
-});
+    globals: {
+      'ts-jest': {
+        tsconfig,
+        isolatedModules: true,
+      },
+    },
+    ...overrides,
+  };
+};

--- a/packages/api/jest.config.ts
+++ b/packages/api/jest.config.ts
@@ -1,19 +1,11 @@
 import { resolve } from 'path';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { pathsToModuleNameMapper } from 'ts-jest/utils';
 
 import { createJestConfig } from '../../jest.config';
 import { compilerOptions } from './tsconfig.json';
 
-const paths = pathsToModuleNameMapper(compilerOptions.paths) as Record<string, string>;
-const moduleNameMapper = Object.keys(paths).reduce<Record<string, string>>(
-  (acc, key) => ({ ...acc, [key]: `<rootDir>/${paths[key]}` }),
-  {},
-);
-
 export default createJestConfig({
   tsconfig: resolve(__dirname, 'tsconfig.json'),
-  moduleNameMapper,
+  paths: compilerOptions.paths,
   overrides: {
     collectCoverageFrom: ['**/*.ts'],
   },

--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -4,7 +4,6 @@ import { createJestConfig } from '../../jest.config';
 
 export default createJestConfig({
   tsconfig: resolve(__dirname, 'tsconfig.json'),
-  moduleNameMapper: { '^@/(.+)': '<rootDir>/src/$1' },
   overrides: {
     testEnvironment: 'jsdom',
     setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],


### PR DESCRIPTION
I moved the logic that allows our test to understand custom TypeScript paths from the api workspace to the root config file. This way it can be easily reused in different workspaces in the future. 