### PR TITLE
feat(api): add transactionally consistent optimistic locking for PrismaEventStore.write (#250)

### DIFF
--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -5,6 +5,7 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["interactiveTransactions"]
 }
 
 model User {

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.service.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.service.ts
@@ -13,10 +13,10 @@ const parseData = (value: unknown): Record<string, unknown> => JSON.parse(typeof
 const parseMetadata = (value: unknown): DefaultCommandMetadata & Record<string, unknown> => {
   const metadata = JSON.parse(typeof value === 'string' ? value : '{}');
 
-  const hasCorrectCorelationId = 'correlationId' in metadata && typeof metadata.correlationId === 'string';
+  const hasCorrectCorrelationId = 'correlationId' in metadata && typeof metadata.correlationId === 'string';
   const hasCorrectCausationId = !('causationId' in metadata) || typeof metadata.causationId === 'string';
 
-  if (!hasCorrectCorelationId || !hasCorrectCausationId) {
+  if (!hasCorrectCorrelationId || !hasCorrectCausationId) {
     throw new Error('Wrong format of the metadata JSON');
   }
 
@@ -51,8 +51,7 @@ export class PrismaEventRepository implements EventRepository {
     events: ApplicationEvent[],
     expectedStreamVersion: EventStreamVersion,
   ): Promise<void> {
-    // todo: do it in transaction!
-    this.prismaService.$transaction(async (prisma) => {
+    await this.prismaService.$transaction(async (prisma) => {
       const currentStreamVersion = await prisma.event.count({ where: { streamId: streamName.streamId } });
 
       if (currentStreamVersion !== expectedStreamVersion) {


### PR DESCRIPTION
Closes #250 