### PR TITLE
feat(api): extend ApplicationEvent type with global order (#262)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -179,7 +179,10 @@ module.exports = {
         'plugin:jest-formatting/recommended',
       ],
       rules: {
-        'jest/expect-expect': [2, { assertFunctionNames: ['expect', '*.expectReadModel'] }],
+        'jest/expect-expect': [
+          2,
+          { assertFunctionNames: ['expect', '*.expectReadModel', '*.expectEventPublishedLastly'] },
+        ],
       },
     },
   ],

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./packages/api
         run: yarn prisma migrate deploy
       - name: Run tests for all files
-        run: yarn test --coverage
+        run: yarn test --coverage --detectOpenHandles
       - name: Stop database
         run: docker-compose down
       - name: Upload server coverage

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -1,8 +1,12 @@
 import { Test } from '@nestjs/testing';
+import { v4 as uuid } from 'uuid';
 
+import { DomainEvent } from '@/module/domain.event';
 import { PrismaService } from '@/prisma/prisma.service';
 import { ApplicationEventBus } from '@/write/shared/application/application.event-bus';
 import { StorableEvent } from '@/write/shared/application/event-repository';
+import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
+import { EventStreamVersion } from '@/write/shared/application/event-stream-version';
 
 import { AppModule } from '../app.module';
 
@@ -10,6 +14,8 @@ export async function cleanupDatabase(prismaService: PrismaService) {
   await Promise.all(
     Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany() : Promise.resolve())),
   );
+
+  await prismaService.$executeRaw`ALTER SEQUENCE "Event_globalOrder_seq" RESTART WITH 1`;
 }
 
 export async function initReadTestModule() {
@@ -35,4 +41,19 @@ export async function initReadTestModule() {
   }
 
   return { prismaService, close, eventOccurred };
+}
+
+export function storableEvent<EventType extends DomainEvent>(
+  eventStreamName: EventStreamName,
+  event: EventType,
+  streamVersion: EventStreamVersion,
+): StorableEvent<EventType> {
+  return {
+    ...event,
+    id: uuid(),
+    occurredAt: new Date(),
+    metadata: { correlationId: uuid(), causationId: uuid() },
+    streamVersion,
+    streamName: eventStreamName,
+  };
 }

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -1,8 +1,8 @@
 import { Test } from '@nestjs/testing';
 
-import { ApplicationEvent } from '@/module/application-command-events';
 import { PrismaService } from '@/prisma/prisma.service';
 import { ApplicationEventBus } from '@/write/shared/application/application.event-bus';
+import { StorableEvent } from '@/write/shared/application/event-repository';
 
 import { AppModule } from '../app.module';
 
@@ -27,8 +27,11 @@ export async function initTestModule() {
   async function close() {
     await app.close();
   }
-  function eventOccurred(event: ApplicationEvent): void {
-    eventBus.publishAll([event]);
+
+  let publishedEvents = 0;
+
+  function eventOccurred(event: StorableEvent): void {
+    eventBus.publishAll([{ ...event, globalOrder: (publishedEvents += 1) }]);
   }
 
   return { prismaService, close, eventOccurred };

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -12,7 +12,7 @@ export async function cleanupDatabase(prismaService: PrismaService) {
   );
 }
 
-export async function initTestModule() {
+export async function initReadTestModule() {
   const app = await Test.createTestingModule({
     imports: [AppModule],
   }).compile();

--- a/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
+++ b/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
@@ -3,17 +3,17 @@ import { AsyncReturnType } from 'type-fest';
 import { v4 as uuid } from 'uuid';
 import waitForExpect from 'wait-for-expect';
 
-import { initTestModule } from '@/common/test-utils';
-import { ApplicationEvent } from '@/module/application-command-events';
+import { initReadTestModule } from '@/common/test-utils';
 import { LearningMaterialsUrlWasGenerated } from '@/module/events/learning-materials-url-was-generated.domain-event';
 import { TaskWasCompleted } from '@/module/events/task-was-completed.domain-event';
 import { TaskWasUncompleted } from '@/module/events/task-was-uncompleted-event.domain-event';
+import { StorableEvent } from '@/write/shared/application/event-repository';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
 
 const statusTask = (
   learningMaterialsId: string,
   type: 'TaskWasUncompleted' | 'TaskWasCompleted',
-): ApplicationEvent<TaskWasUncompleted | TaskWasCompleted> => {
+): StorableEvent<TaskWasUncompleted | TaskWasCompleted> => {
   return {
     type,
     id: uuid(),
@@ -38,31 +38,31 @@ const givenData = (id: string) => {
 };
 
 async function courseProgressTestModule() {
-  const { prismaService, close, eventOccurred } = await initTestModule();
+  const { prismaService, close, eventOccurred } = await initReadTestModule();
 
   async function expectReadModel(expectation: {
     learningMaterialsId: string;
     readModel: Omit<CourseProgress, 'id'> | null;
   }) {
-    await waitForExpect(() =>
-      expect(
-        prismaService.courseProgress.findUnique({
-          where: { learningMaterialsId: expectation.learningMaterialsId },
-          select: {
-            id: false,
-            courseUserId: true,
-            learningMaterialsCompletedTasks: true,
-            learningMaterialsId: true,
-          },
-        }),
-      ).resolves.toStrictEqual(expectation.readModel),
-    );
+    await waitForExpect(async () => {
+      const readModel = await prismaService.courseProgress.findUnique({
+        where: { learningMaterialsId: expectation.learningMaterialsId },
+        select: {
+          id: false,
+          courseUserId: true,
+          learningMaterialsCompletedTasks: true,
+          learningMaterialsId: true,
+        },
+      });
+
+      expect(readModel).toStrictEqual(expectation.readModel);
+    });
   }
 
   return { eventOccurred, expectReadModel, close };
 }
 
-const learningMaterialsUrlWasGeneratedWithId = (id: string): ApplicationEvent<LearningMaterialsUrlWasGenerated> => {
+const learningMaterialsUrlWasGeneratedWithId = (id: string): StorableEvent<LearningMaterialsUrlWasGenerated> => {
   const SAMPLE_MATERIALS_URL = 'https://app.process.st/runs/jNMTGn96H8Xe3H8DbcpJOg';
   const courseUserId = `userId-${id}`;
 

--- a/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
+++ b/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
@@ -5,10 +5,9 @@ import waitForExpect from 'wait-for-expect';
 
 import { initTestModule } from '@/common/test-utils';
 import { LearningMaterialsUrlWasGenerated } from '@/events/learning-materials-url-was-generated.domain-event';
-import { ApplicationEvent } from '@/module/application-command-events';
 import { UserId } from '@/users/users.types';
+import { StorableEvent } from '@/write/shared/application/event-repository';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
-import {StorableEvent} from "@/write/shared/application/event-repository";
 
 const SAMPLE_MATERIALS_URL = 'https://app.process.st/runs/jNMTGn96H8Xe3H8DbcpJOg';
 

--- a/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
+++ b/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
@@ -3,7 +3,7 @@ import { AsyncReturnType } from 'type-fest';
 import { v4 as uuid } from 'uuid';
 import waitForExpect from 'wait-for-expect';
 
-import { initTestModule } from '@/common/test-utils';
+import { initReadTestModule } from '@/common/test-utils';
 import { LearningMaterialsUrlWasGenerated } from '@/events/learning-materials-url-was-generated.domain-event';
 import { UserId } from '@/users/users.types';
 import { StorableEvent } from '@/write/shared/application/event-repository';
@@ -12,7 +12,7 @@ import { EventStreamName } from '@/write/shared/application/event-stream-name.va
 const SAMPLE_MATERIALS_URL = 'https://app.process.st/runs/jNMTGn96H8Xe3H8DbcpJOg';
 
 async function learningMaterialsTestModule() {
-  const { prismaService, close, eventOccurred } = await initTestModule();
+  const { prismaService, close, eventOccurred } = await initReadTestModule();
 
   async function expectReadModel(expectation: { courseUserId: UserId; readModel: LearningMaterials | null }) {
     await waitForExpect(async () => {

--- a/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
+++ b/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
@@ -8,6 +8,7 @@ import { LearningMaterialsUrlWasGenerated } from '@/events/learning-materials-ur
 import { ApplicationEvent } from '@/module/application-command-events';
 import { UserId } from '@/users/users.types';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
+import {StorableEvent} from "@/write/shared/application/event-repository";
 
 const SAMPLE_MATERIALS_URL = 'https://app.process.st/runs/jNMTGn96H8Xe3H8DbcpJOg';
 
@@ -29,7 +30,7 @@ async function learningMaterialsTestModule() {
 
 function learningMaterialsUrlWasGeneratedForUser(
   courseUserId: UserId,
-): ApplicationEvent<LearningMaterialsUrlWasGenerated> {
+): StorableEvent<LearningMaterialsUrlWasGenerated> {
   return {
     type: 'LearningMaterialsUrlWasGenerated',
     id: uuid(),

--- a/packages/api/src/module/shared/application-command-events.ts
+++ b/packages/api/src/module/shared/application-command-events.ts
@@ -49,6 +49,8 @@ export abstract class AbstractApplicationCommand<
   }
 }
 
+export type EventGlobalOrder = number;
+
 export interface ApplicationEvent<
   DomainEventType extends DomainEvent = DomainEvent,
   EventMetadata extends DefaultEventMetadata = DefaultEventMetadata,
@@ -60,4 +62,5 @@ export interface ApplicationEvent<
   readonly metadata: EventMetadata;
   readonly streamVersion: EventStreamVersion;
   readonly streamName: EventStreamName;
+  readonly globalOrder: EventGlobalOrder;
 }

--- a/packages/api/src/module/write/learning-materials-url/generate-learning-materials-url.spec.ts
+++ b/packages/api/src/module/write/learning-materials-url/generate-learning-materials-url.spec.ts
@@ -2,7 +2,6 @@ import { AsyncReturnType } from 'type-fest';
 
 import { GenerateLearningMaterialsUrlApplicationCommand } from '@/commands/generate-learning-materials-url.application-command';
 import { LearningMaterialsUrlWasGenerated } from '@/events/learning-materials-url-was-generated.domain-event';
-import { ApplicationEvent } from '@/module/application-command-events';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
 
 import { generateLearningMaterialsUrlTestModule } from './generate-learning-materials-url.test-module';
@@ -21,10 +20,8 @@ describe('Generate Learning Materials URL', () => {
   it('given learning materials url was NOT generated before for the user, then should be generated', async () => {
     // Given
     const courseUserId = moduleUnderTest.randomUserId();
-    const generateAt = new Date();
 
     // When
-    moduleUnderTest.timeTravelTo(generateAt);
     await moduleUnderTest.executeCommand(() => ({
       class: GenerateLearningMaterialsUrlApplicationCommand,
       type: 'GenerateLearningMaterialsUrl',
@@ -32,42 +29,28 @@ describe('Generate Learning Materials URL', () => {
     }));
 
     // Then
-    const lastPublishedEvents = await moduleUnderTest.getLastPublishedEvents();
-
-    const learningMaterialsUrlWasGenerated = {
+    await moduleUnderTest.expectEventPublishedLastly<LearningMaterialsUrlWasGenerated>({
       type: 'LearningMaterialsUrlWasGenerated',
-      id: 'generatedId1',
-      occurredAt: generateAt,
       data: {
         learningMaterialsId: 'generatedProcessStId_1',
         courseUserId,
         materialsUrl: 'https://app.process.st/runs/generatedProcessStId_1/tasks/oFBpTVsw_DS_O5B-OgtHXA',
       },
-      metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-      streamVersion: 1,
       streamName: EventStreamName.from('LearningMaterialsUrl', courseUserId),
-    };
-
-    expect(lastPublishedEvents).toStrictEqual([learningMaterialsUrlWasGenerated]);
+    });
   });
 
   it('given learning materials url was generated before for the user, then should not be generated', async () => {
     // Given
     const courseUserId = moduleUnderTest.randomUserId();
     const learningMaterialsId = 'sbAPITNMsl2wW6j2cg1H2A';
-    const generateAt = new Date();
-    const learningMaterialsUrlWasGenerated: ApplicationEvent<LearningMaterialsUrlWasGenerated> = {
+    const learningMaterialsUrlWasGenerated: LearningMaterialsUrlWasGenerated = {
       type: 'LearningMaterialsUrlWasGenerated',
-      id: 'generatedId1',
-      occurredAt: generateAt,
       data: {
         learningMaterialsId,
         courseUserId,
         materialsUrl: 'https://app.process.st/runs/Jan%20Kowalski-sbAPITNMsl2wW6j2cg1H2A/tasks/oFBpTVsw_DS_O5B-OgtHXA',
       },
-      metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-      streamVersion: 1,
-      streamName: EventStreamName.from('LearningMaterialsUrl', 'existing-user-id'),
     };
 
     await moduleUnderTest.eventOccurred(
@@ -76,12 +59,7 @@ describe('Generate Learning Materials URL', () => {
       0,
     );
 
-    // When
-    const retryGenerateAt = new Date();
-
-    moduleUnderTest.timeTravelTo(retryGenerateAt);
-
-    // Then
+    // When - Then
     await expect(() =>
       moduleUnderTest.executeCommand(() => ({
         class: GenerateLearningMaterialsUrlApplicationCommand,
@@ -94,18 +72,13 @@ describe('Generate Learning Materials URL', () => {
   it('given learning materials url was generated before for another user, then should be generated', async () => {
     // Given
     const anotherUserId = moduleUnderTest.randomUserId();
-    const learningMaterialsUrlWasGeneratedForAnotherUser: ApplicationEvent<LearningMaterialsUrlWasGenerated> = {
+    const learningMaterialsUrlWasGeneratedForAnotherUser: LearningMaterialsUrlWasGenerated = {
       type: 'LearningMaterialsUrlWasGenerated',
-      id: 'another-user-learning-materials-was-generated-event-id',
-      occurredAt: moduleUnderTest.currentTime(),
       data: {
         courseUserId: anotherUserId,
         learningMaterialsId: 'sbAPITNMsl2wW6j2cg1H2A',
         materialsUrl: 'https://app.process.st/runs/Jan%20Kowalski-sbAPITNMsl2wW6j2cg1H2A/tasks/oFBpTVsw_DS_O5B-OgtHXA',
       },
-      metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-      streamVersion: 0,
-      streamName: EventStreamName.from('LearningMaterialsUrl', anotherUserId),
     };
 
     await moduleUnderTest.eventOccurred(
@@ -116,9 +89,7 @@ describe('Generate Learning Materials URL', () => {
 
     // When
     const userId = moduleUnderTest.randomUserId();
-    const generateAt = new Date();
 
-    moduleUnderTest.timeTravelTo(generateAt);
     await moduleUnderTest.executeCommand(() => ({
       class: GenerateLearningMaterialsUrlApplicationCommand,
       type: 'GenerateLearningMaterialsUrl',
@@ -126,22 +97,14 @@ describe('Generate Learning Materials URL', () => {
     }));
 
     // Then
-    const lastPublishedEvents = await moduleUnderTest.getLastPublishedEvents();
-
-    const learningMaterialsUrlWasGenerated: ApplicationEvent<LearningMaterialsUrlWasGenerated> = {
+    await moduleUnderTest.expectEventPublishedLastly<LearningMaterialsUrlWasGenerated>({
       type: 'LearningMaterialsUrlWasGenerated',
-      id: 'generatedId1',
-      occurredAt: generateAt,
       data: {
         learningMaterialsId: 'generatedProcessStId_1',
         courseUserId: userId,
         materialsUrl: 'https://app.process.st/runs/generatedProcessStId_1/tasks/oFBpTVsw_DS_O5B-OgtHXA',
       },
-      metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-      streamVersion: 1,
       streamName: EventStreamName.from('LearningMaterialsUrl', userId),
-    };
-
-    expect(lastPublishedEvents).toStrictEqual([learningMaterialsUrlWasGenerated]);
+    });
   });
 });

--- a/packages/api/src/module/write/shared/application/event-repository.ts
+++ b/packages/api/src/module/write/shared/application/event-repository.ts
@@ -1,4 +1,5 @@
-import { ApplicationEvent } from '@/module/application-command-events';
+import { ApplicationEvent, DefaultEventMetadata } from '@/module/application-command-events';
+import { DomainEvent } from '@/module/domain.event';
 
 import { EventStream } from './application-service';
 import { EventStreamName } from './event-stream-name.value-object';
@@ -6,12 +7,17 @@ import { EventStreamVersion } from './event-stream-version';
 
 export const EVENT_REPOSITORY = Symbol('EVENT_REPOSITORY');
 
+export type StorableEvent<
+  DomainEventType extends DomainEvent = DomainEvent,
+  EventMetadata extends DefaultEventMetadata = DefaultEventMetadata,
+> = Omit<ApplicationEvent<DomainEventType, EventMetadata>, 'globalOrder'>;
+
 export interface EventRepository {
   read(streamName: EventStreamName): Promise<EventStream>;
 
   write(
     streamName: EventStreamName,
-    events: ApplicationEvent[],
+    events: StorableEvent[],
     expectedStreamVersion: EventStreamVersion,
-  ): Promise<void>;
+  ): Promise<ApplicationEvent[]>;
 }

--- a/packages/api/src/module/write/shared/infrastructure/application-service/event-application-service.ts
+++ b/packages/api/src/module/write/shared/infrastructure/application-service/event-application-service.ts
@@ -5,7 +5,7 @@ import { DomainEvent } from '@/module/domain.event';
 
 import { ApplicationEventBus } from '../../application/application.event-bus';
 import { ApplicationExecutionContext, ApplicationService, DomainLogic } from '../../application/application-service';
-import { EVENT_REPOSITORY, EventRepository } from '../../application/event-repository';
+import { EVENT_REPOSITORY, EventRepository, StorableEvent } from '../../application/event-repository';
 import { EventStreamName } from '../../application/event-stream-name.value-object';
 import { EventStreamVersion } from '../../application/event-stream-version';
 import { ID_GENERATOR, IdGenerator } from '../../application/id-generator';
@@ -33,7 +33,7 @@ export class EventApplicationService implements ApplicationService {
       }),
     );
 
-    const uncommitedEvents: ApplicationEvent[] = resultDomainEvents.map((e, index) => ({
+    const eventsToStore: StorableEvent[] = resultDomainEvents.map((e, index) => ({
       data: e.data,
       type: e.type,
       id: this.idGenerator.generate(),
@@ -43,9 +43,9 @@ export class EventApplicationService implements ApplicationService {
       streamName,
     }));
 
-    await this.eventRepository.write(streamName, uncommitedEvents, streamVersion);
+    const eventsToPublish = await this.eventRepository.write(streamName, eventsToStore, streamVersion);
 
-    await this.eventBus.publishAll(uncommitedEvents);
+    await this.eventBus.publishAll(eventsToPublish);
   }
 
   private static streamVersion(eventStream?: ApplicationEvent[]): EventStreamVersion {

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ApplicationEvent } from '@/module/application-command-events';
 
 import { EventStream } from '../../application/application-service';
-import { EventRepository } from '../../application/event-repository';
+import { EventRepository, StorableEvent } from '../../application/event-repository';
 import { EventStreamName } from '../../application/event-stream-name.value-object';
 import { EventStreamVersion } from '../../application/event-stream-version';
 import { TIME_PROVIDER, TimeProvider } from '../../application/time-provider.port';
@@ -24,17 +24,17 @@ export class InMemoryEventRepository implements EventRepository {
 
   async write(
     streamName: EventStreamName,
-    events: ApplicationEvent[],
+    events: StorableEvent[],
     expectedStreamVersion: EventStreamVersion,
-  ): Promise<void> {
-    await Promise.all(events.map((value, index) => this.writeOne(streamName, value, expectedStreamVersion + index)));
+  ): Promise<ApplicationEvent[]> {
+    return Promise.all(events.map((value, index) => this.writeOne(streamName, value, expectedStreamVersion + index)));
   }
 
   private writeOne(
     streamName: EventStreamName,
-    event: ApplicationEvent,
+    event: StorableEvent,
     expectedStreamVersion: EventStreamVersion,
-  ): Promise<void> {
+  ): Promise<ApplicationEvent> {
     const foundStream = this.eventStreams[streamName.raw];
 
     if (foundStream && foundStream.find((e) => e.id === event.id)) {
@@ -43,20 +43,26 @@ export class InMemoryEventRepository implements EventRepository {
 
     const streamVersion = !foundStream ? 0 : foundStream.length;
 
+    const storeEvent = { ...event, globalOrder: this.globalEventsCount() };
+
     if (!foundStream) {
       if (expectedStreamVersion !== 0) {
         return Promise.reject(new Error(`Event stream was modified concurrently!`));
       }
 
-      this.eventStreams[streamName.raw] = [event];
+      this.eventStreams[streamName.raw] = [storeEvent];
     } else {
       if (expectedStreamVersion && expectedStreamVersion !== streamVersion) {
         return Promise.reject(new Error(`Event stream was modified concurrently!`));
       }
 
-      this.eventStreams[streamName.raw].push(event);
+      this.eventStreams[streamName.raw].push(storeEvent);
     }
 
-    return Promise.resolve();
+    return Promise.resolve(storeEvent);
+  }
+
+  private globalEventsCount(): number {
+    return Object.entries(this.eventStreams).reduce((acc, stream) => acc + stream.length, 0);
   }
 }

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
@@ -1,0 +1,94 @@
+import { Test } from '@nestjs/testing';
+import { AsyncReturnType } from 'type-fest';
+import { v4 as uuid } from 'uuid';
+
+import { cleanupDatabase, storableEvent } from '@/common/test-utils';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { PrismaService } from '@/prisma/prisma.service';
+import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
+import { EventStreamVersion } from '@/write/shared/application/event-stream-version';
+import { PrismaEventRepository } from '@/write/shared/infrastructure/event-repository/prisma-event-repository.service';
+
+async function initTestPrismaEventRepository() {
+  const app = await Test.createTestingModule({
+    imports: [PrismaModule],
+  }).compile();
+
+  await app.init();
+
+  const prismaService = app.get<PrismaService>(PrismaService);
+  const eventRepository = new PrismaEventRepository(prismaService, { currentTime: () => new Date() });
+
+  await cleanupDatabase(prismaService);
+
+  function close() {
+    return app.close();
+  }
+
+  function randomEventStreamId() {
+    return uuid();
+  }
+
+  return { eventRepository, randomEventStreamId, close };
+}
+
+type SampleDomainEvent = {
+  type: 'SampleDomainEvent';
+  data: {
+    value1: string;
+    value2: number;
+  };
+};
+
+describe('Prisma Event Repository', () => {
+  let sut: AsyncReturnType<typeof initTestPrismaEventRepository>;
+
+  beforeEach(async () => {
+    sut = await initTestPrismaEventRepository();
+  });
+
+  afterEach(async () => {
+    await sut.close();
+  });
+
+  it('write and read single storable event and return application event with globalOrder', async () => {
+    // Given
+    const { eventRepository } = sut;
+    const streamCategory = 'SampleEventStreamCategory';
+    const streamId = sut.randomEventStreamId();
+    const streamName = EventStreamName.props({ streamCategory, streamId });
+    const sampleDomainEvent: SampleDomainEvent = {
+      type: 'SampleDomainEvent',
+      data: {
+        value1: 'sampleValue1',
+        value2: 123,
+      },
+    };
+    const expectedStreamVersion: EventStreamVersion = 0;
+    const sampleStorableEvent = storableEvent<SampleDomainEvent>(streamName, sampleDomainEvent, expectedStreamVersion);
+
+    // When
+    const writeResult = await eventRepository.write(streamName, [sampleStorableEvent], expectedStreamVersion);
+
+    // Then
+    const storedEvents = [
+      {
+        type: sampleStorableEvent.type,
+        data: sampleStorableEvent.data,
+        id: sampleStorableEvent.id,
+        occurredAt: sampleStorableEvent.occurredAt,
+        metadata: sampleStorableEvent.metadata,
+        streamVersion: sampleStorableEvent.streamVersion,
+        streamName: sampleStorableEvent.streamName,
+        globalOrder: 1,
+      },
+    ];
+
+    expect(writeResult).toStrictEqual(storedEvents);
+
+    // When
+    const readEventStream = await eventRepository.read(streamName);
+
+    expect(readEventStream).toStrictEqual(storedEvents);
+  });
+});


### PR DESCRIPTION
Closes #262 

It'd be nice to merge it before starting further work. 
Change some commonly used concept (ApplicationEvent) as a first step in order to guarantee app responsiveness (fault tolerance). More described in issue #262.
