### PR TITLE
feat(api): exclude streamVersion and streamName from StorableEvent (#226)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "start": "cross-env NODE_ENV=production node dist/api/src/main",
     "start:prod": "node dist/api/src/main",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config jest-e2e.config.ts",
     "generate": "prisma generate",

--- a/packages/api/prisma/migrations/20210902133615_remove_wrong_constraint/migration.sql
+++ b/packages/api/prisma/migrations/20210902133615_remove_wrong_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "streamName";

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -44,8 +44,6 @@ model Event {
   data           Json
   metadata       Json
   globalOrder    Int @default(autoincrement())
-
-  @@unique(fields: [streamId, streamCategory], name: "streamName")
 }
 
 model Course {
@@ -60,8 +58,8 @@ enum Role {
 }
 
 model CourseProgress {
-  id       String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  courseUserId   String @unique
-  learningMaterialsId   String @unique
-  learningMaterialsCompletedTasks Int
+  id                                String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  courseUserId                      String @unique
+  learningMaterialsId               String @unique
+  learningMaterialsCompletedTasks   Int
 }

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -6,7 +6,6 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { ApplicationEventBus } from '@/write/shared/application/application.event-bus';
 import { StorableEvent } from '@/write/shared/application/event-repository';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
-import { EventStreamVersion } from '@/write/shared/application/event-stream-version';
 
 import { AppModule } from '../app.module';
 
@@ -36,24 +35,23 @@ export async function initReadTestModule() {
 
   let publishedEvents = 0;
 
-  function eventOccurred(event: StorableEvent): void {
-    eventBus.publishAll([{ ...event, globalOrder: (publishedEvents += 1) }]);
+  function eventOccurred(event: StorableEvent, streamName: EventStreamName): void {
+    publishedEvents += 1;
+    eventBus.publishAll([{ ...event, globalOrder: publishedEvents, streamVersion: publishedEvents, streamName }]);
   }
 
   return { prismaService, close, eventOccurred };
 }
 
-export function storableEvent<EventType extends DomainEvent>(
-  eventStreamName: EventStreamName,
-  event: EventType,
-  streamVersion: EventStreamVersion,
-): StorableEvent<EventType> {
+export function storableEvent<EventType extends DomainEvent>(event: EventType): StorableEvent<EventType> {
   return {
     ...event,
     id: uuid(),
     occurredAt: new Date(),
     metadata: { correlationId: uuid(), causationId: uuid() },
-    streamVersion,
-    streamName: eventStreamName,
   };
+}
+
+export function sequence(length: number) {
+  return Array.from(Array(length).keys());
 }

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -11,8 +11,9 @@ import { AppModule } from '../app.module';
 
 export async function cleanupDatabase(prismaService: PrismaService) {
   await Promise.all(
-    Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany({}) : Promise.resolve())),
+    Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany() : Promise.resolve())),
   );
+  
   await prismaService.$executeRaw`ALTER SEQUENCE "Event_globalOrder_seq" RESTART WITH 1`;
 }
 

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -10,10 +10,12 @@ import { EventStreamName } from '@/write/shared/application/event-stream-name.va
 import { AppModule } from '../app.module';
 
 export async function cleanupDatabase(prismaService: PrismaService) {
+  console.log("CLEANUP DATABASE")
+  await prismaService.$executeRaw`TRUNCATE TABLE "Event"`;
   await Promise.all(
-    Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany() : Promise.resolve())),
+    Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany({}) : Promise.resolve())),
   );
-
+  await prismaService.event.deleteMany({}).then((c) => console.log('DELETED', c));
   await prismaService.$executeRaw`ALTER SEQUENCE "Event_globalOrder_seq" RESTART WITH 1`;
 }
 

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -35,9 +35,9 @@ export async function initReadTestModule() {
 
   let publishedEvents = 0;
 
-  function eventOccurred(event: StorableEvent, streamName: EventStreamName): void {
+  async function eventOccurred(event: StorableEvent, streamName: EventStreamName): Promise<void> {
     publishedEvents += 1;
-    eventBus.publishAll([{ ...event, globalOrder: publishedEvents, streamVersion: publishedEvents, streamName }]);
+    await eventBus.publishAll([{ ...event, globalOrder: publishedEvents, streamVersion: publishedEvents, streamName }]);
   }
 
   return { prismaService, close, eventOccurred };

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -10,12 +10,9 @@ import { EventStreamName } from '@/write/shared/application/event-stream-name.va
 import { AppModule } from '../app.module';
 
 export async function cleanupDatabase(prismaService: PrismaService) {
-  console.log("CLEANUP DATABASE")
-  await prismaService.$executeRaw`TRUNCATE TABLE "Event"`;
   await Promise.all(
     Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany({}) : Promise.resolve())),
   );
-  await prismaService.event.deleteMany({}).then((c) => console.log('DELETED', c));
   await prismaService.$executeRaw`ALTER SEQUENCE "Event_globalOrder_seq" RESTART WITH 1`;
 }
 

--- a/packages/api/src/common/test-utils.ts
+++ b/packages/api/src/common/test-utils.ts
@@ -13,7 +13,7 @@ export async function cleanupDatabase(prismaService: PrismaService) {
   await Promise.all(
     Object.values(prismaService).map((table) => (table?.deleteMany ? table.deleteMany() : Promise.resolve())),
   );
-  
+
   await prismaService.$executeRaw`ALTER SEQUENCE "Event_globalOrder_seq" RESTART WITH 1`;
 }
 

--- a/packages/api/src/module/automation/send-email-when-learning-materials-url-was-generated/learning-materials-url-was-generated-event-handler.service.ts
+++ b/packages/api/src/module/automation/send-email-when-learning-materials-url-was-generated/learning-materials-url-was-generated-event-handler.service.ts
@@ -8,6 +8,5 @@ import { ApplicationEvent } from '@/module/application-command-events';
 @Injectable()
 export class LearningMaterialsUrlWasGeneratedEventHandler {
   @OnEvent('LearningMaterialsUrl.*')
-  handleLearningMaterialsUrlDomainEvent(_event: ApplicationEvent<LearningMaterialsUrlWasGenerated>) {
-  }
+  handleLearningMaterialsUrlDomainEvent(_event: ApplicationEvent<LearningMaterialsUrlWasGenerated>) {}
 }

--- a/packages/api/src/module/automation/send-email-when-learning-materials-url-was-generated/learning-materials-url-was-generated-event-handler.service.ts
+++ b/packages/api/src/module/automation/send-email-when-learning-materials-url-was-generated/learning-materials-url-was-generated-event-handler.service.ts
@@ -8,7 +8,6 @@ import { ApplicationEvent } from '@/module/application-command-events';
 @Injectable()
 export class LearningMaterialsUrlWasGeneratedEventHandler {
   @OnEvent('LearningMaterialsUrl.*')
-  handleLearningMaterialsUrlDomainEvent(event: ApplicationEvent<LearningMaterialsUrlWasGenerated>) {
-    console.log('TODO: Send Email', event);
+  handleLearningMaterialsUrlDomainEvent(_event: ApplicationEvent<LearningMaterialsUrlWasGenerated>) {
   }
 }

--- a/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
+++ b/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
@@ -23,8 +23,6 @@ const statusTask = (
       taskId: '2',
     },
     metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-    streamVersion: 1,
-    streamName: EventStreamName.from('LearningMaterialsTasks', learningMaterialsId),
   };
 };
 
@@ -76,8 +74,6 @@ const learningMaterialsUrlWasGeneratedWithId = (id: string): StorableEvent<Learn
       materialsUrl: SAMPLE_MATERIALS_URL,
     },
     metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-    streamVersion: 1,
-    streamName: EventStreamName.from('LearningMaterialsUrl', courseUserId),
   };
 };
 
@@ -96,7 +92,10 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id));
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedWithId(id),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,
@@ -108,7 +107,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasCompleted'));
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasCompleted'),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     // Then
     const learningMaterialCompletedTaskAfterEvent = initialLearningMaterialCompletedTask + 1;
@@ -127,7 +129,10 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id));
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedWithId(id),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,
@@ -139,7 +144,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasCompleted'));
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasCompleted'),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     // Then
     const learningMaterialCompletedTaskAfterEvent = initialLearningMaterialCompletedTask + 1;
@@ -154,7 +162,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasUncompleted'));
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasUncompleted'),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     // Then
     await moduleUnderTest.expectReadModel({
@@ -172,7 +183,10 @@ describe('Read Slice | CourseProgress', () => {
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
     // When
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id));
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedWithId(id),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     // Then
     await moduleUnderTest.expectReadModel({
@@ -185,7 +199,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasUncompleted'));
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasUncompleted'),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
     // Then
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,

--- a/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
+++ b/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
@@ -92,7 +92,7 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       learningMaterialsUrlWasGeneratedWithId(id),
       EventStreamName.from('LearningMaterialsUrl', courseUserId),
     );
@@ -107,7 +107,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       statusTask(learningMaterialsId, 'TaskWasCompleted'),
       EventStreamName.from('LearningMaterialsTasks', courseUserId),
     );
@@ -129,7 +129,7 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       learningMaterialsUrlWasGeneratedWithId(id),
       EventStreamName.from('LearningMaterialsUrl', courseUserId),
     );
@@ -144,7 +144,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       statusTask(learningMaterialsId, 'TaskWasCompleted'),
       EventStreamName.from('LearningMaterialsTasks', courseUserId),
     );
@@ -162,7 +162,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       statusTask(learningMaterialsId, 'TaskWasUncompleted'),
       EventStreamName.from('LearningMaterialsTasks', courseUserId),
     );
@@ -183,7 +183,7 @@ describe('Read Slice | CourseProgress', () => {
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       learningMaterialsUrlWasGeneratedWithId(id),
       EventStreamName.from('LearningMaterialsUrl', courseUserId),
     );
@@ -199,7 +199,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       statusTask(learningMaterialsId, 'TaskWasUncompleted'),
       EventStreamName.from('LearningMaterialsTasks', courseUserId),
     );

--- a/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
+++ b/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
@@ -92,10 +92,9 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    moduleUnderTest.eventOccurred(
-      learningMaterialsUrlWasGeneratedWithId(id),
-      EventStreamName.from('LearningMaterialsUrl', courseUserId),
-    );
+    const eventStreamName = EventStreamName.from('LearningMaterialsUrl', courseUserId);
+
+    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id), eventStreamName);
 
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,
@@ -107,10 +106,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
-      statusTask(learningMaterialsId, 'TaskWasCompleted'),
-      EventStreamName.from('LearningMaterialsUrl', courseUserId),
-    );
+    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasCompleted'), eventStreamName);
 
     // Then
     const learningMaterialCompletedTaskAfterEvent = initialLearningMaterialCompletedTask + 1;
@@ -129,10 +125,9 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    moduleUnderTest.eventOccurred(
-      learningMaterialsUrlWasGeneratedWithId(id),
-      EventStreamName.from('LearningMaterialsUrl', courseUserId),
-    );
+    const eventStreamName = EventStreamName.from('LearningMaterialsUrl', courseUserId);
+
+    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id), eventStreamName);
 
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,
@@ -144,10 +139,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
-      statusTask(learningMaterialsId, 'TaskWasCompleted'),
-      EventStreamName.from('LearningMaterialsUrl', courseUserId),
-    );
+    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasCompleted'), eventStreamName);
 
     // Then
     const learningMaterialCompletedTaskAfterEvent = initialLearningMaterialCompletedTask + 1;
@@ -162,10 +154,7 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
-      statusTask(learningMaterialsId, 'TaskWasUncompleted'),
-      EventStreamName.from('LearningMaterialsUrl', courseUserId),
-    );
+    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasUncompleted'), eventStreamName);
 
     // Then
     await moduleUnderTest.expectReadModel({

--- a/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
+++ b/packages/api/src/module/read/course-progress/course-progress.read-module.spec.ts
@@ -92,9 +92,10 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    const eventStreamName = EventStreamName.from('LearningMaterialsUrl', courseUserId);
-
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id), eventStreamName);
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedWithId(id),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,
@@ -106,7 +107,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasCompleted'), eventStreamName);
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasCompleted'),
+      EventStreamName.from('LearningMaterialsTasks', courseUserId),
+    );
 
     // Then
     const learningMaterialCompletedTaskAfterEvent = initialLearningMaterialCompletedTask + 1;
@@ -125,9 +129,10 @@ describe('Read Slice | CourseProgress', () => {
     // Given
     const { id, courseUserId, learningMaterialsId, initialLearningMaterialCompletedTask } = givenData(uuid());
 
-    const eventStreamName = EventStreamName.from('LearningMaterialsUrl', courseUserId);
-
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedWithId(id), eventStreamName);
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedWithId(id),
+      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+    );
 
     await moduleUnderTest.expectReadModel({
       learningMaterialsId,
@@ -139,7 +144,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasCompleted'), eventStreamName);
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasCompleted'),
+      EventStreamName.from('LearningMaterialsTasks', courseUserId),
+    );
 
     // Then
     const learningMaterialCompletedTaskAfterEvent = initialLearningMaterialCompletedTask + 1;
@@ -154,7 +162,10 @@ describe('Read Slice | CourseProgress', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(statusTask(learningMaterialsId, 'TaskWasUncompleted'), eventStreamName);
+    moduleUnderTest.eventOccurred(
+      statusTask(learningMaterialsId, 'TaskWasUncompleted'),
+      EventStreamName.from('LearningMaterialsTasks', courseUserId),
+    );
 
     // Then
     await moduleUnderTest.expectReadModel({
@@ -190,7 +201,7 @@ describe('Read Slice | CourseProgress', () => {
     // When
     moduleUnderTest.eventOccurred(
       statusTask(learningMaterialsId, 'TaskWasUncompleted'),
-      EventStreamName.from('LearningMaterialsUrl', courseUserId),
+      EventStreamName.from('LearningMaterialsTasks', courseUserId),
     );
     // Then
     await moduleUnderTest.expectReadModel({

--- a/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
+++ b/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
@@ -40,8 +40,6 @@ function learningMaterialsUrlWasGeneratedForUser(
       materialsUrl: SAMPLE_MATERIALS_URL,
     },
     metadata: { correlationId: 'generatedId1', causationId: 'generatedId1' },
-    streamVersion: 1,
-    streamName: EventStreamName.from('LearningMaterialsUrl', courseUserId),
   };
 }
 
@@ -62,7 +60,10 @@ describe('Read Slice | Learning Materials', () => {
     const userId2 = uuid();
 
     // When
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedForUser(userId1));
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedForUser(userId1),
+      EventStreamName.from('LearningMaterialsUrl', userId1),
+    );
 
     // Then
     await moduleUnderTest.expectReadModel({
@@ -79,7 +80,10 @@ describe('Read Slice | Learning Materials', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(learningMaterialsUrlWasGeneratedForUser(userId2));
+    moduleUnderTest.eventOccurred(
+      learningMaterialsUrlWasGeneratedForUser(userId2),
+      EventStreamName.from('LearningMaterialsUrl', userId2),
+    );
 
     // Then
     await moduleUnderTest.expectReadModel({

--- a/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
+++ b/packages/api/src/module/read/learning-materials/learning-materials.read-module.spec.ts
@@ -60,7 +60,7 @@ describe('Read Slice | Learning Materials', () => {
     const userId2 = uuid();
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       learningMaterialsUrlWasGeneratedForUser(userId1),
       EventStreamName.from('LearningMaterialsUrl', userId1),
     );
@@ -80,7 +80,7 @@ describe('Read Slice | Learning Materials', () => {
     });
 
     // When
-    moduleUnderTest.eventOccurred(
+    await moduleUnderTest.eventOccurred(
       learningMaterialsUrlWasGeneratedForUser(userId2),
       EventStreamName.from('LearningMaterialsUrl', userId2),
     );

--- a/packages/api/src/module/write/learning-materials-url/generate-learning-materials-url.test-module.ts
+++ b/packages/api/src/module/write/learning-materials-url/generate-learning-materials-url.test-module.ts
@@ -104,8 +104,6 @@ export async function generateLearningMaterialsUrlTestModule() {
       id: randomEventId(),
       occurredAt: testTimeProvider.currentTime(),
       metadata: { correlationId: uuid(), causationId: uuid() },
-      streamVersion,
-      streamName: eventStreamName,
     };
 
     await eventRepository.write(eventStreamName, [storableEvent], streamVersion);

--- a/packages/api/src/module/write/learning-materials-url/generate-learning-materials-url.test-module.ts
+++ b/packages/api/src/module/write/learning-materials-url/generate-learning-materials-url.test-module.ts
@@ -20,7 +20,7 @@ import {
 } from './application/learning-materials-url-generator';
 import { USERS_PORT, UsersPort } from './application/users.port';
 
-type EventBusSpy = jest.SpyInstance<void, [ApplicationEvent[]]>;
+type EventBusSpy = jest.SpyInstance<Promise<void>, [ApplicationEvent[]]>;
 
 export type ExpectedPublishEvent<EventType extends DomainEvent> = {
   type: EventType['type'];

--- a/packages/api/src/module/write/shared/application/application.event-bus.ts
+++ b/packages/api/src/module/write/shared/application/application.event-bus.ts
@@ -7,19 +7,13 @@ import { ApplicationEvent } from '@/module/application-command-events';
 export class ApplicationEventBus {
   constructor(private readonly eventEmitter: EventEmitter2) {}
 
-  publishAll<EventType extends ApplicationEvent>(events: EventType[]): void {
-    events.map((e) => {
-      // eslint-disable-next-line no-console
-      console.log('[ApplicationEventBus] Event published', {
-        stream: e.streamName.raw,
-        type: e.type,
-        id: e.id,
-        data: e.data,
-      });
+  async publishAll<EventType extends ApplicationEvent>(events: EventType[]): Promise<void> {
+    await Promise.all(
+      events.map((e) => {
+        const event = `${e.streamName.streamCategory}.${e.type}`;
 
-      const event = `${e.streamName.streamCategory}.${e.type}`;
-
-      return this.eventEmitter.emit(event, e);
-    });
+        return this.eventEmitter.emitAsync(event, e);
+      }),
+    );
   }
 }

--- a/packages/api/src/module/write/shared/application/event-repository.ts
+++ b/packages/api/src/module/write/shared/application/event-repository.ts
@@ -12,7 +12,7 @@ export type StorableEvent<
   EventMetadata extends DefaultEventMetadata = DefaultEventMetadata,
 > = Omit<ApplicationEvent<DomainEventType, EventMetadata>, 'globalOrder' | 'streamVersion' | 'streamName'>;
 
-export type ReadAllFilter = { streamCategory?: string; eventType?: string; fromGlobalPosition?: number };
+export type ReadAllFilter = { streamCategory?: string; eventTypes?: string[]; fromGlobalPosition?: number };
 
 export interface EventRepository {
   read(streamName: EventStreamName): Promise<EventStream>;

--- a/packages/api/src/module/write/shared/application/event-repository.ts
+++ b/packages/api/src/module/write/shared/application/event-repository.ts
@@ -10,7 +10,9 @@ export const EVENT_REPOSITORY = Symbol('EVENT_REPOSITORY');
 export type StorableEvent<
   DomainEventType extends DomainEvent = DomainEvent,
   EventMetadata extends DefaultEventMetadata = DefaultEventMetadata,
-> = Omit<ApplicationEvent<DomainEventType, EventMetadata>, 'globalOrder'>;
+> = Omit<ApplicationEvent<DomainEventType, EventMetadata>, 'globalOrder' | 'streamVersion' | 'streamName'>;
+
+export type ReadAllFilter = { streamCategory?: string; eventType?: string; fromGlobalPosition?: number };
 
 export interface EventRepository {
   read(streamName: EventStreamName): Promise<EventStream>;
@@ -20,4 +22,6 @@ export interface EventRepository {
     events: StorableEvent[],
     expectedStreamVersion: EventStreamVersion,
   ): Promise<ApplicationEvent[]>;
+
+  readAll(filter: Partial<ReadAllFilter>): Promise<ApplicationEvent[]>;
 }

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ApplicationEvent } from '@/module/application-command-events';
 
 import { EventStream } from '../../application/application-service';
-import { EventRepository, StorableEvent } from '../../application/event-repository';
+import { EventRepository, ReadAllFilter, StorableEvent } from '../../application/event-repository';
 import { EventStreamName } from '../../application/event-stream-name.value-object';
 import { EventStreamVersion } from '../../application/event-stream-version';
 import { TIME_PROVIDER, TimeProvider } from '../../application/time-provider.port';
@@ -43,7 +43,12 @@ export class InMemoryEventRepository implements EventRepository {
 
     const streamVersion = !foundStream ? 0 : foundStream.length;
 
-    const storeEvent = { ...event, globalOrder: this.globalEventsCount() };
+    const storeEvent = {
+      ...event,
+      globalOrder: this.globalEventsCount(),
+      streamName,
+      streamVersion: expectedStreamVersion + 1,
+    };
 
     if (!foundStream) {
       if (expectedStreamVersion !== 0) {
@@ -64,5 +69,9 @@ export class InMemoryEventRepository implements EventRepository {
 
   private globalEventsCount(): number {
     return Object.entries(this.eventStreams).reduce((acc, stream) => acc + stream.length, 0);
+  }
+
+  readAll(_filter: Partial<ReadAllFilter>): Promise<ApplicationEvent[]> {
+    return Promise.resolve([]);
   }
 }

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
@@ -71,7 +71,14 @@ export class InMemoryEventRepository implements EventRepository {
     return Object.entries(this.eventStreams).reduce((acc, stream) => acc + stream.length, 0);
   }
 
-  readAll(_filter: Partial<ReadAllFilter>): Promise<ApplicationEvent[]> {
-    return Promise.resolve([]);
+  async readAll(filter: Partial<ReadAllFilter>): Promise<ApplicationEvent[]> {
+    const { streamCategory, eventType, fromGlobalPosition } = filter;
+
+    return Object.values(this.eventStreams)
+      .reduce((acc, stream) => acc.concat(stream), [])
+      .filter((e) => (streamCategory ? e.streamName.streamCategory === streamCategory : true))
+      .filter((e) => (eventType ? e.type === eventType : true))
+      .filter((e) => (fromGlobalPosition ? e.globalOrder >= fromGlobalPosition : true))
+      .sort((e1, e2) => e1.globalOrder - e2.globalOrder);
   }
 }

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/in-memory-event-repository.ts
@@ -72,13 +72,13 @@ export class InMemoryEventRepository implements EventRepository {
   }
 
   async readAll(filter: Partial<ReadAllFilter>): Promise<ApplicationEvent[]> {
-    const { streamCategory, eventType, fromGlobalPosition } = filter;
+    const { streamCategory, eventTypes, fromGlobalPosition } = filter;
 
     return Object.values(this.eventStreams)
       .reduce((acc, stream) => acc.concat(stream), [])
-      .filter((e) => (streamCategory ? e.streamName.streamCategory === streamCategory : true))
-      .filter((e) => (eventType ? e.type === eventType : true))
-      .filter((e) => (fromGlobalPosition ? e.globalOrder >= fromGlobalPosition : true))
+      .filter((e) => !streamCategory || e.streamName.streamCategory)
+      .filter((e) => !eventTypes || eventTypes.includes(e.type))
+      .filter((e) => !fromGlobalPosition || e.globalOrder >= fromGlobalPosition)
       .sort((e1, e2) => e1.globalOrder - e2.globalOrder);
   }
 }

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.service.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.service.ts
@@ -105,6 +105,7 @@ export class PrismaEventRepository implements EventRepository {
     };
     const storedEvents = await this.prismaService.event.findMany({
       where,
+      orderBy: { globalOrder: 'asc' },
     });
 
     return storedEvents.map((e) => ({

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.service.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.service.ts
@@ -101,7 +101,7 @@ export class PrismaEventRepository implements EventRepository {
           }
         : undefined,
       streamCategory: filter.streamCategory,
-      type: filter.eventType,
+      type: filter.eventTypes ? { in: filter.eventTypes } : undefined,
     };
     const storedEvents = await this.prismaService.event.findMany({
       where,

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
@@ -156,12 +156,27 @@ describe('Prisma Event Repository', () => {
     await eventRepository.write(streamName, [...sampleEventsToStore, ...anotherSampleEventsToStore], 0);
 
     // Then
-    const result = await eventRepository.readAll({
+    const result1 = await eventRepository.readAll({
       streamCategory,
-      fromGlobalPosition: 100,
-      eventType: 'AnotherSampleDomainEvent',
+      fromGlobalPosition: 99,
+      eventTypes: ['SampleDomainEvent', 'AnotherSampleDomainEvent'],
     });
 
-    expect(result.length).toBe(1);
+    expect(result1.length).toBe(2);
+
+    // Then
+    const result2 = await eventRepository.readAll({});
+
+    expect(result2.length).toBe(100);
+
+    // Then
+    const result3 = await eventRepository.readAll({ fromGlobalPosition: 40, eventTypes: ['SampleDomainEvent'] });
+
+    expect(result3.length).toBe(11);
+
+    // Then
+    const result4 = await eventRepository.readAll({ fromGlobalPosition: 999 });
+
+    expect(result4.length).toBe(0);
   });
 });

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
@@ -2,11 +2,11 @@ import { Test } from '@nestjs/testing';
 import { AsyncReturnType } from 'type-fest';
 import { v4 as uuid } from 'uuid';
 
-import { cleanupDatabase, storableEvent } from '@/common/test-utils';
+import { cleanupDatabase, sequence, storableEvent } from '@/common/test-utils';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { PrismaService } from '@/prisma/prisma.service';
+import { StorableEvent } from '@/write/shared/application/event-repository';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
-import { EventStreamVersion } from '@/write/shared/application/event-stream-version';
 import { PrismaEventRepository } from '@/write/shared/infrastructure/event-repository/prisma-event-repository.service';
 
 async function initTestPrismaEventRepository() {
@@ -40,6 +40,14 @@ type SampleDomainEvent = {
   };
 };
 
+type AnotherSampleDomainEvent = {
+  type: 'AnotherSampleDomainEvent';
+  data: {
+    value1: string;
+    value2: number;
+  };
+};
+
 describe('Prisma Event Repository', () => {
   let sut: AsyncReturnType<typeof initTestPrismaEventRepository>;
 
@@ -55,8 +63,8 @@ describe('Prisma Event Repository', () => {
     // Given
     const { eventRepository } = sut;
     const streamCategory = 'SampleEventStreamCategory';
-    const streamId = sut.randomEventStreamId();
-    const streamName = EventStreamName.props({ streamCategory, streamId });
+    const streamName01 = EventStreamName.props({ streamCategory, streamId: sut.randomEventStreamId() });
+    const streamName2 = EventStreamName.props({ streamCategory, streamId: sut.randomEventStreamId() });
     const sampleDomainEvent: SampleDomainEvent = {
       type: 'SampleDomainEvent',
       data: {
@@ -64,31 +72,98 @@ describe('Prisma Event Repository', () => {
         value2: 123,
       },
     };
-    const expectedStreamVersion: EventStreamVersion = 0;
-    const sampleStorableEvent = storableEvent<SampleDomainEvent>(streamName, sampleDomainEvent, expectedStreamVersion);
+    const sampleStorableEvent0 = storableEvent<SampleDomainEvent>(sampleDomainEvent);
+    const sampleStorableEvent1 = storableEvent<SampleDomainEvent>(sampleDomainEvent);
+    const sampleStorableEvent2 = storableEvent<SampleDomainEvent>(sampleDomainEvent);
 
     // When
-    const writeResult = await eventRepository.write(streamName, [sampleStorableEvent], expectedStreamVersion);
+    const writeResult0 = await eventRepository.write(streamName01, [sampleStorableEvent0], 0);
+    const writeResult1 = await eventRepository.write(streamName01, [sampleStorableEvent1], 1);
+    const writeResult2 = await eventRepository.write(streamName2, [sampleStorableEvent2], 0);
 
     // Then
-    const storedEvents = [
-      {
-        type: sampleStorableEvent.type,
-        data: sampleStorableEvent.data,
-        id: sampleStorableEvent.id,
-        occurredAt: sampleStorableEvent.occurredAt,
-        metadata: sampleStorableEvent.metadata,
-        streamVersion: sampleStorableEvent.streamVersion,
-        streamName: sampleStorableEvent.streamName,
-        globalOrder: 1,
-      },
-    ];
+    const storedEvent0 = {
+      type: sampleStorableEvent0.type,
+      data: sampleStorableEvent0.data,
+      id: sampleStorableEvent0.id,
+      occurredAt: sampleStorableEvent0.occurredAt,
+      metadata: sampleStorableEvent0.metadata,
+      streamVersion: 1,
+      streamName: streamName01,
+      globalOrder: 1,
+    };
+    const storedEvent1 = {
+      type: sampleStorableEvent1.type,
+      data: sampleStorableEvent1.data,
+      id: sampleStorableEvent1.id,
+      occurredAt: sampleStorableEvent1.occurredAt,
+      metadata: sampleStorableEvent1.metadata,
+      streamVersion: 2,
+      streamName: streamName01,
+      globalOrder: 2,
+    };
+    const storedEvent2 = {
+      type: sampleStorableEvent2.type,
+      data: sampleStorableEvent2.data,
+      id: sampleStorableEvent2.id,
+      occurredAt: sampleStorableEvent2.occurredAt,
+      metadata: sampleStorableEvent2.metadata,
+      streamVersion: 1,
+      streamName: streamName2,
+      globalOrder: 3,
+    };
 
-    expect(writeResult).toStrictEqual(storedEvents);
+    expect(writeResult0).toStrictEqual([storedEvent0]);
+    expect(writeResult1).toStrictEqual([storedEvent1]);
+    expect(writeResult2).toStrictEqual([storedEvent2]);
 
     // When
-    const readEventStream = await eventRepository.read(streamName);
+    const readEventStream = await eventRepository.read(streamName01);
 
-    expect(readEventStream).toStrictEqual(storedEvents);
+    expect(readEventStream).toStrictEqual([storedEvent0, storedEvent1]);
+  });
+
+  describe('readAll with filter', () => {
+    it('filter by eventStreamCategory, eventType, fromGlobalPosition', async () => {
+      // Given
+      const { eventRepository } = sut;
+      const streamCategory = 'SampleEventStreamCategory';
+      const streamId = sut.randomEventStreamId();
+      const streamName = EventStreamName.props({ streamCategory, streamId });
+
+      const sampleDomainEvent: SampleDomainEvent = {
+        type: 'SampleDomainEvent',
+        data: {
+          value1: 'sampleValue1',
+          value2: 123,
+        },
+      };
+      const anotherSampleDomainEvent: AnotherSampleDomainEvent = {
+        type: 'AnotherSampleDomainEvent',
+        data: {
+          value1: 'sampleValue1',
+          value2: 123,
+        },
+      };
+
+      const sampleEventsToStore: StorableEvent[] = sequence(50).map(() =>
+        storableEvent<SampleDomainEvent>(sampleDomainEvent),
+      );
+      const anotherSampleEventsToStore: StorableEvent[] = sequence(50).map(() =>
+        storableEvent<AnotherSampleDomainEvent>(anotherSampleDomainEvent),
+      );
+
+      // When
+      await eventRepository.write(streamName, [...sampleEventsToStore, ...anotherSampleEventsToStore], 0);
+
+      // Then
+      const result = await eventRepository.readAll({
+        streamCategory,
+        fromGlobalPosition: 100,
+        eventType: 'AnotherSampleDomainEvent',
+      });
+
+      expect(result.length).toBe(1);
+    });
   });
 });

--- a/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
+++ b/packages/api/src/module/write/shared/infrastructure/event-repository/prisma-event-repository.spec.ts
@@ -123,47 +123,45 @@ describe('Prisma Event Repository', () => {
     expect(readEventStream).toStrictEqual([storedEvent0, storedEvent1]);
   });
 
-  describe('readAll with filter', () => {
-    it('filter by eventStreamCategory, eventType, fromGlobalPosition', async () => {
-      // Given
-      const { eventRepository } = sut;
-      const streamCategory = 'SampleEventStreamCategory';
-      const streamId = sut.randomEventStreamId();
-      const streamName = EventStreamName.props({ streamCategory, streamId });
+  it('readAll with filter by eventStreamCategory, eventType, fromGlobalPosition', async () => {
+    // Given
+    const { eventRepository } = sut;
+    const streamCategory = 'SampleEventStreamCategory';
+    const streamId = sut.randomEventStreamId();
+    const streamName = EventStreamName.props({ streamCategory, streamId });
 
-      const sampleDomainEvent: SampleDomainEvent = {
-        type: 'SampleDomainEvent',
-        data: {
-          value1: 'sampleValue1',
-          value2: 123,
-        },
-      };
-      const anotherSampleDomainEvent: AnotherSampleDomainEvent = {
-        type: 'AnotherSampleDomainEvent',
-        data: {
-          value1: 'sampleValue1',
-          value2: 123,
-        },
-      };
+    const sampleDomainEvent: SampleDomainEvent = {
+      type: 'SampleDomainEvent',
+      data: {
+        value1: 'sampleValue1',
+        value2: 123,
+      },
+    };
+    const anotherSampleDomainEvent: AnotherSampleDomainEvent = {
+      type: 'AnotherSampleDomainEvent',
+      data: {
+        value1: 'sampleValue1',
+        value2: 123,
+      },
+    };
 
-      const sampleEventsToStore: StorableEvent[] = sequence(50).map(() =>
-        storableEvent<SampleDomainEvent>(sampleDomainEvent),
-      );
-      const anotherSampleEventsToStore: StorableEvent[] = sequence(50).map(() =>
-        storableEvent<AnotherSampleDomainEvent>(anotherSampleDomainEvent),
-      );
+    const sampleEventsToStore: StorableEvent[] = sequence(50).map(() =>
+      storableEvent<SampleDomainEvent>(sampleDomainEvent),
+    );
+    const anotherSampleEventsToStore: StorableEvent[] = sequence(50).map(() =>
+      storableEvent<AnotherSampleDomainEvent>(anotherSampleDomainEvent),
+    );
 
-      // When
-      await eventRepository.write(streamName, [...sampleEventsToStore, ...anotherSampleEventsToStore], 0);
+    // When
+    await eventRepository.write(streamName, [...sampleEventsToStore, ...anotherSampleEventsToStore], 0);
 
-      // Then
-      const result = await eventRepository.readAll({
-        streamCategory,
-        fromGlobalPosition: 100,
-        eventType: 'AnotherSampleDomainEvent',
-      });
-
-      expect(result.length).toBe(1);
+    // Then
+    const result = await eventRepository.readAll({
+      streamCategory,
+      fromGlobalPosition: 100,
+      eventType: 'AnotherSampleDomainEvent',
     });
+
+    expect(result.length).toBe(1);
   });
 });


### PR DESCRIPTION
Enabler for #226

Additional changes:
* add `readAll` method for EventRepository. Will be useful for event handlers to fetch not processed events in case of failure / processing logic change.
* `--runInBand` for tests. Test must be executed sequentially if db is shared resource
* easier testing with possibility to await on event publishing (use EventEmitter2.emitAsync)
