### PR TITLE
fix(website): fix navbar logo sizing and mentor testimonial spacing

### DIFF
--- a/packages/website/src/components/Navbar/BaseNavbar.tsx
+++ b/packages/website/src/components/Navbar/BaseNavbar.tsx
@@ -29,7 +29,7 @@ const NavbarElements = [
   },
 ];
 
-const baseLogoProps = { cursor: 'pointer', width: '100%', maxWidth: '280px', height: '100%', maxHeight: '40px' };
+const baseLogoProps = { cursor: 'pointer', maxWidth: '280px', maxHeight: '40px' };
 
 export const MobileBaseNavbar = () => {
   const logoLayout = useBreakpointValue({ sm: 'square', md: 'horizontal' } as const);
@@ -68,7 +68,7 @@ export const DesktopBaseNavbar = () => {
           <LogoBlackSquare {...baseLogoProps} />
         )}
       </Link>
-      <Flex>
+      <Flex align="center">
         {NavbarElements.map((element) => (
           <NavbarItem key={element.text} text={element.text} href={element.destinationLink} />
         ))}

--- a/packages/website/src/components/Navbar/Navbar.tsx
+++ b/packages/website/src/components/Navbar/Navbar.tsx
@@ -28,7 +28,7 @@ export const Navbar = () => {
     >
       <Center bgColor="white" shadow={hasShadow ? 'large' : undefined}>
         <HStack
-          py="18px"
+          py="16px"
           px={{ base: '8px', sm: '18px', md: '24px', lg: '40px' }}
           width="min(1920px, 100%)"
           justifyContent="space-between"

--- a/packages/website/src/components/Testimonials/MentorTestimonials/MentorTestimonialCard.tsx
+++ b/packages/website/src/components/Testimonials/MentorTestimonials/MentorTestimonialCard.tsx
@@ -1,5 +1,4 @@
-import { Center } from '@coderscamp/ui/components/Center';
-import { VStack } from '@coderscamp/ui/components/Stack';
+import { HStack, VStack } from '@coderscamp/ui/components/Stack';
 import { Typography } from '@coderscamp/ui/components/Typography';
 
 import { MentorAvatar } from '../MentorAvatar';
@@ -11,8 +10,8 @@ export const MentorTestimonialCard = ({ content, image, name, company, companyPo
       <Typography size={{ base: 'md', sm: 'lg' }} color="gray.700">
         {content}
       </Typography>
-      <Center>
-        <MentorAvatar mr="16px" src={image} alt={name} />
+      <HStack spacing="16px">
+        <MentorAvatar src={image} alt={name} />
         <VStack alignItems="flex-start" spacing="0px">
           <Typography size="lg" weight="medium" color="gray.900">
             {name}
@@ -24,7 +23,7 @@ export const MentorTestimonialCard = ({ content, image, name, company, companyPo
             {company}
           </Typography>
         </VStack>
-      </Center>
+      </HStack>
     </VStack>
   );
 };


### PR DESCRIPTION
**Mentor testimonial spacing**
from
<img width="279" alt="CleanShot 2021-09-06 at 18 35 21@2x" src="https://user-images.githubusercontent.com/22938071/132245398-2c4f4866-9d18-4941-bf8a-a82d4d244769.png">
to
<img width="298" alt="CleanShot 2021-09-06 at 18 36 52@2x" src="https://user-images.githubusercontent.com/22938071/132245487-10df9b1f-40e5-4e1a-9f5a-1b75171a41b3.png">


**Navbar logo sizing**
from
<img width="1064" alt="CleanShot 2021-09-06 at 18 36 05@2x" src="https://user-images.githubusercontent.com/22938071/132245435-31ccbca6-2aae-4b29-9477-c7d935207697.png">
to
<img width="1065" alt="CleanShot 2021-09-06 at 18 36 20@2x" src="https://user-images.githubusercontent.com/22938071/132245457-e9092cbb-8138-4cb5-ab68-e5d949f15339.png">
