### PR TITLE
feat(api): open-api specification as contract testing tool (#225)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,6 +177,7 @@ module.exports = {
         'test-utils.ts',
         '*Handlers.ts',
         '**/mocks/*',
+        'jest-setup.ts',
       ],
       extends: [
         'plugin:testing-library/react',

--- a/packages/api/jest-setup.ts
+++ b/packages/api/jest-setup.ts
@@ -1,3 +1,5 @@
+import appRoot from 'app-root-path';
+import jestOpenAPI from 'jest-openapi';
 import { set } from 'leaked-handles';
 
 // detect where are memory leaks in test
@@ -5,4 +7,10 @@ set({
   fullStack: true,
   timeout: 30000,
   debugSockets: true,
+});
+
+export const initOpenApiExpect = () => jestOpenAPI(`${appRoot}/packages/api/rest-api-docs.yaml`);
+
+beforeAll(() => {
+  initOpenApiExpect();
 });

--- a/packages/api/jest-setup.ts
+++ b/packages/api/jest-setup.ts
@@ -1,5 +1,7 @@
 import appRoot from 'app-root-path';
 import jestOpenAPI from 'jest-openapi';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { set } from 'leaked-handles';
 
 // detect where are memory leaks in test
@@ -10,7 +12,3 @@ set({
 });
 
 export const initOpenApiExpect = () => jestOpenAPI(`${appRoot}/packages/api/rest-api-docs.yaml`);
-
-beforeAll(() => {
-  initOpenApiExpect();
-});

--- a/packages/api/jest.config.ts
+++ b/packages/api/jest.config.ts
@@ -9,6 +9,6 @@ export default createJestConfig({
   overrides: {
     testTimeout: 6000,
     collectCoverageFrom: ['**/*.ts'],
-    setupFiles: ['./jest-setup.ts'],
+    setupFilesAfterEnv: ['./jest-setup.ts'],
   },
 });

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -67,6 +67,7 @@
     "@types/supertest": "2.0.11",
     "@types/uuid": "8.3.1",
     "@types/yamljs": "0.2.31",
+    "jest-openapi": "0.14.0",
     "node-mocks-http": "1.10.1",
     "prisma": "3.0.2",
     "supertest": "6.1.6",

--- a/packages/api/src/app.middlewares.ts
+++ b/packages/api/src/app.middlewares.ts
@@ -1,0 +1,12 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
+
+import { env } from '@/shared/env';
+import { DomainRuleViolationExceptionFilter } from '@/shared/errors/domain-rule-violation.exception-filter';
+
+export function setupMiddlewares(app: INestApplication) {
+  app.setGlobalPrefix('api');
+  app.use(cookieParser(env.COOKIE_SECRET));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.useGlobalFilters(new DomainRuleViolationExceptionFilter());
+}

--- a/packages/api/src/app.swagger.ts
+++ b/packages/api/src/app.swagger.ts
@@ -1,0 +1,14 @@
+import { INestApplication } from '@nestjs/common';
+import { SwaggerCustomOptions, SwaggerModule } from '@nestjs/swagger';
+import YAML from 'yamljs';
+
+export function setupSwagger(app: INestApplication) {
+  const swaggerUiOptions: SwaggerCustomOptions = {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+    customSiteTitle: 'CodersCamp App REST API docs',
+  };
+
+  SwaggerModule.setup('swagger', app, YAML.load('./rest-api-docs.yaml'), swaggerUiOptions);
+}

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,24 +1,12 @@
-import { INestApplication, Logger, ValidationPipe } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { SwaggerCustomOptions, SwaggerModule } from '@nestjs/swagger';
-import cookieParser from 'cookie-parser';
-import YAML from 'yamljs';
 
+import { setupMiddlewares } from './app.middlewares';
 import { AppModule } from './app.module';
+import { setupSwagger } from './app.swagger';
 import { env, validateEnv } from './shared/env';
 
 const logger = new Logger('bootstrap');
-
-function setupSwagger(app: INestApplication) {
-  const swaggerUiOptions: SwaggerCustomOptions = {
-    swaggerOptions: {
-      persistAuthorization: true,
-    },
-    customSiteTitle: 'CodersCamp App REST API docs',
-  };
-
-  SwaggerModule.setup('swagger', app, YAML.load('./rest-api-docs.yaml'), swaggerUiOptions);
-}
 
 async function bootstrap() {
   try {
@@ -26,9 +14,7 @@ async function bootstrap() {
 
     const app = await NestFactory.create(AppModule);
 
-    app.setGlobalPrefix('api');
-    app.use(cookieParser(env.COOKIE_SECRET));
-    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    setupMiddlewares(app);
     setupSwagger(app);
 
     await app.listen(env.PORT);

--- a/packages/api/src/module/write/learning-materials-tasks/presentation/rest/process-st-events.rest-controller.ts
+++ b/packages/api/src/module/write/learning-materials-tasks/presentation/rest/process-st-events.rest-controller.ts
@@ -11,7 +11,7 @@ export class LearningMaterialsTaskRestController {
   constructor(private readonly commandBus: CommandBus, private readonly commandFactory: ApplicationCommandFactory) {}
 
   @Post('task-checked-unchecked')
-  @HttpCode(200)
+  @HttpCode(204)
   async taskCheckedUnchecked(
     @Body() { id: learningMaterialsId, data: { id: taskId, status } }: TaskCompletedRequestBody,
   ): Promise<void> {

--- a/packages/api/src/module/write/user-registration/application/register-user.command-handler.ts
+++ b/packages/api/src/module/write/user-registration/application/register-user.command-handler.ts
@@ -5,7 +5,7 @@ import { registerError } from '@coderscamp/shared/models/auth/register';
 
 import { RegisterUserApplicationCommand } from '@/commands/register-user';
 import { isUniqueConstraintError } from '@/prisma/prisma.errors';
-import { DomainRuleViolationException } from '@/shared/domain-rule-violation.exception';
+import { DomainRuleViolationException } from '@/shared/errors/domain-rule-violation.exception';
 import { APPLICATION_SERVICE, ApplicationService } from '@/write/shared/application/application-service';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
 import { PASSWORD_ENCODER, PasswordEncoder } from '@/write/shared/application/password-encoder';

--- a/packages/api/src/module/write/user-registration/application/register-user.command-handler.ts
+++ b/packages/api/src/module/write/user-registration/application/register-user.command-handler.ts
@@ -5,7 +5,7 @@ import { registerError } from '@coderscamp/shared/models/auth/register';
 
 import { RegisterUserApplicationCommand } from '@/commands/register-user';
 import { isUniqueConstraintError } from '@/prisma/prisma.errors';
-import { DomainRuleViolationError } from '@/shared/domain-rule-violation.error';
+import { DomainRuleViolationException } from '@/shared/domain-rule-violation.exception';
 import { APPLICATION_SERVICE, ApplicationService } from '@/write/shared/application/application-service';
 import { EventStreamName } from '@/write/shared/application/event-stream-name.value-object';
 import { PASSWORD_ENCODER, PasswordEncoder } from '@/write/shared/application/password-encoder';
@@ -40,7 +40,7 @@ export class RegisterUserCommandHandler implements ICommandHandler<RegisterUserA
       await this.emails.unlockEmailAddress({ emailAddress: command.data.emailAddress });
 
       if (isUniqueConstraintError(ex)) {
-        throw new DomainRuleViolationError(registerError.REGISTRATION_FORM_ALREADY_EXISTS, { cause: ex, command });
+        throw new DomainRuleViolationException(registerError.USER_WAS_ALREADY_REGISTERED, { cause: ex, command });
       }
     }
   }

--- a/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.spec.ts
+++ b/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.spec.ts
@@ -7,13 +7,7 @@ import { DomainRuleViolationException } from '@/shared/errors/domain-rule-violat
 import { initTestModuleRestApi } from '@/shared/test-utils';
 import { UserRegistrationRestController } from '@/write/user-registration/presentation/rest/user-registration.rest-controller';
 
-import { initOpenApiExpect } from '../../../../../../jest-setup';
-
-initOpenApiExpect();
-
-// fixme: ADDRESS ALREADY IN USE
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('User Registration | REST API', () => {
+describe('User Registration | REST API', () => {
   let restUnderTest: AsyncReturnType<typeof initTestModuleRestApi>;
 
   beforeAll(async () => {

--- a/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.spec.ts
+++ b/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.spec.ts
@@ -7,6 +7,10 @@ import { DomainRuleViolationException } from '@/shared/errors/domain-rule-violat
 import { initTestModuleRestApi } from '@/shared/test-utils';
 import { UserRegistrationRestController } from '@/write/user-registration/presentation/rest/user-registration.rest-controller';
 
+import { initOpenApiExpect } from '../../../../../../jest-setup';
+
+initOpenApiExpect();
+
 describe('User Registration | REST API', () => {
   let restUnderTest: AsyncReturnType<typeof initTestModuleRestApi>;
 

--- a/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.spec.ts
+++ b/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.spec.ts
@@ -1,0 +1,86 @@
+import { HttpStatus } from '@nestjs/common';
+import { AsyncReturnType } from 'type-fest';
+
+import { registerError } from '@coderscamp/shared/models/auth/register';
+
+import { DomainRuleViolationException } from '@/shared/errors/domain-rule-violation.exception';
+import { initTestModuleRestApi } from '@/shared/test-utils';
+import { UserRegistrationRestController } from '@/write/user-registration/presentation/rest/user-registration.rest-controller';
+
+import { initOpenApiExpect } from '../../../../../../jest-setup';
+
+initOpenApiExpect();
+
+// fixme: ADDRESS ALREADY IN USE
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('User Registration | REST API', () => {
+  let restUnderTest: AsyncReturnType<typeof initTestModuleRestApi>;
+
+  beforeAll(async () => {
+    restUnderTest = await initTestModuleRestApi(UserRegistrationRestController);
+    restUnderTest.commandBusExecute.mockClear();
+  });
+
+  afterAll(async () => {
+    await restUnderTest.close();
+  });
+
+  describe('/POST user-registration', () => {
+    it(`success`, async () => {
+      // Given
+      restUnderTest.commandBusExecute.mockImplementation(() => Promise.resolve());
+
+      // When
+      const response = await restUnderTest.http.post('/api/user-registration').send({
+        fullName: 'John Kowalsky',
+        email: 'jan.kowalski@nowak.pl',
+        password: 'samplePassword123',
+      });
+
+      // Then
+      expect(response.status).toBe(HttpStatus.CREATED);
+      expect(response.body.userId).toBeDefined();
+      expect(response).toSatisfyApiSpec();
+    });
+
+    it(`invalid request body - without password field`, async () => {
+      // When
+      const response = await restUnderTest.http.post('/api/user-registration').send({
+        fullName: 'John Kowalsky',
+        email: 'jan.kowalski@nowak.pl',
+      });
+
+      // Then
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body).toStrictEqual({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ['"password" is required', '"password" must be a string'],
+        error: 'Bad Request',
+      });
+      expect(response).toSatisfyApiSpec();
+    });
+
+    it(`command rejected because REGISTRATION_FORM_ALREADY_EXISTS`, async () => {
+      // Given
+      restUnderTest.commandBusExecute.mockRejectedValue(
+        new DomainRuleViolationException(registerError.USER_WAS_ALREADY_REGISTERED),
+      );
+
+      // When
+      const response = await restUnderTest.http.post('/api/user-registration').send({
+        fullName: 'John Kowalsky',
+        email: 'jan.kowalski@nowak.pl',
+        password: 'samplePassword123',
+      });
+
+      // Then
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body).toStrictEqual({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: 'USER_WAS_ALREADY_REGISTERED',
+        error: 'Bad Request',
+      });
+      expect(response).toSatisfyApiSpec();
+    });
+  });
+});

--- a/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.ts
+++ b/packages/api/src/module/write/user-registration/presentation/rest/user-registration.rest-controller.ts
@@ -1,10 +1,10 @@
-import { BadRequestException, Body, Controller, HttpCode, InternalServerErrorException, Post } from '@nestjs/common';
+import { BadRequestException, Body, Controller, InternalServerErrorException, Post } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
 
 import { REGISTER_ENDPOINT, RegisterBody, RegisterResponse } from '@coderscamp/shared/models/auth/register';
 
 import { RegisterUserApplicationCommand } from '@/commands/register-user';
-import { isDomainRuleViolation } from '@/shared/domain-rule-violation.error';
+import { isDomainRuleViolation } from '@/shared/errors/domain-rule-violation.exception';
 import { ApplicationCommandFactory } from '@/write/shared/application/application-command.factory';
 
 @Controller()
@@ -12,7 +12,6 @@ export class UserRegistrationRestController {
   constructor(private readonly commandBus: CommandBus, private readonly commandFactory: ApplicationCommandFactory) {}
 
   @Post(REGISTER_ENDPOINT)
-  @HttpCode(204)
   async register(@Body() body: RegisterBody): Promise<RegisterResponse> {
     const command = this.commandFactory.applicationCommand((idGenerator) => ({
       class: RegisterUserApplicationCommand,
@@ -27,12 +26,14 @@ export class UserRegistrationRestController {
 
     try {
       await this.commandBus.execute(command);
+
+      return { userId: command.data.userId };
     } catch (ex) {
       if (isDomainRuleViolation(ex)) {
-        throw new BadRequestException(ex);
+        throw new BadRequestException(ex.message);
       }
 
-      throw new InternalServerErrorException(ex);
+      throw new InternalServerErrorException();
     }
   }
 }

--- a/packages/api/src/module/write/user-registration/user-registration.spec.ts
+++ b/packages/api/src/module/write/user-registration/user-registration.spec.ts
@@ -110,6 +110,6 @@ describe('User Registration', () => {
         },
       }));
 
-    await expect(command).rejects.toEqual(new Error(registerError.REGISTRATION_FORM_ALREADY_EXISTS));
+    await expect(command).rejects.toEqual(new Error(registerError.USER_WAS_ALREADY_REGISTERED));
   });
 });

--- a/packages/api/src/shared/errors/domain-rule-violation.exception-filter.ts
+++ b/packages/api/src/shared/errors/domain-rule-violation.exception-filter.ts
@@ -1,0 +1,16 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+
+import { DomainRuleViolationException } from '@/shared/errors/domain-rule-violation.exception';
+
+@Catch(DomainRuleViolationException)
+export class DomainRuleViolationExceptionFilter implements ExceptionFilter {
+  catch(exception: DomainRuleViolationException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.BAD_REQUEST).json({
+      message: exception.message,
+    });
+  }
+}

--- a/packages/api/src/shared/errors/domain-rule-violation.exception.ts
+++ b/packages/api/src/shared/errors/domain-rule-violation.exception.ts
@@ -1,12 +1,12 @@
 import { ApplicationCommand } from '@/module/application-command-events';
 
 export type DomainErrorDetails = Partial<{ readonly cause: Error; readonly command: ApplicationCommand }>;
-export class DomainRuleViolationError extends Error {
+export class DomainRuleViolationException extends Error {
   constructor(message: string, readonly details?: DomainErrorDetails) {
     super(message);
   }
 }
 
-export function isDomainRuleViolation(ex: unknown): ex is DomainRuleViolationError {
-  return ex instanceof DomainRuleViolationError;
+export function isDomainRuleViolation(ex: unknown): ex is DomainRuleViolationException {
+  return ex instanceof DomainRuleViolationException;
 }

--- a/packages/api/src/shared/test-utils.ts
+++ b/packages/api/src/shared/test-utils.ts
@@ -4,6 +4,7 @@ import { ModuleMetadata } from '@nestjs/common/interfaces/modules/module-metadat
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { CommandBus, ICommand } from '@nestjs/cqrs';
 import { Test, TestingModule, TestingModuleBuilder } from '@nestjs/testing';
+import supertest from 'supertest';
 import { v4 as uuid } from 'uuid';
 import waitForExpect from 'wait-for-expect';
 

--- a/packages/shared/src/models/auth/login.ts
+++ b/packages/shared/src/models/auth/login.ts
@@ -8,13 +8,13 @@ export const LOGIN_ENDPOINT = '/auth/login';
 export class LoginBody implements Pick<AuthUser, 'email' | 'password'> {
   @Expose()
   @IsString()
-  @IsEmail({}, { message: 'Niepoprawny format adresu e-mail' })
-  @IsNotEmpty({ message: 'To pole jest wymagane' })
+  @IsEmail({}, { message: '"email" must be properly formatted' })
+  @IsNotEmpty({ message: '"email" is required' })
   email: string;
 
   @Expose()
-  @IsString()
-  @IsNotEmpty({ message: 'To pole jest wymagane' })
+  @IsString({ message: '"password" must be a string' })
+  @IsNotEmpty({ message: '"password" is required' })
   password: string;
 }
 

--- a/packages/shared/src/models/auth/register.ts
+++ b/packages/shared/src/models/auth/register.ts
@@ -2,27 +2,27 @@ import { Expose } from 'class-transformer';
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export const registerError = {
-  REGISTRATION_FORM_ALREADY_EXISTS: 'REGISTRATION_FORM_ALREADY_EXISTS',
+  USER_WAS_ALREADY_REGISTERED: 'USER_WAS_ALREADY_REGISTERED',
 };
 
 export const REGISTER_ENDPOINT = '/user-registration';
 
 export class RegisterBody {
   @Expose()
-  @IsString()
-  @IsNotEmpty({ message: 'To pole jest wymagane' })
+  @IsString({ message: '"fullName" must be a string' })
+  @IsNotEmpty({ message: '"fullName" is required' })
   fullName: string;
 
   @Expose()
   @IsString()
-  @IsEmail({}, { message: 'Niepoprawny format adresu e-mail' })
-  @IsNotEmpty({ message: 'To pole jest wymagane' })
+  @IsEmail({}, { message: '"email" must be properly formatted' })
+  @IsNotEmpty({ message: '"email" is required' })
   email: string;
 
   @Expose()
-  @IsString()
-  @IsNotEmpty({ message: 'To pole jest wymagane' })
+  @IsString({ message: '"password" must be a string' })
+  @IsNotEmpty({ message: '"password" is required' })
   password: string;
 }
 
-export type RegisterResponse = void;
+export type RegisterResponse = { userId: string };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,6 +2735,7 @@ __metadata:
     dayjs: 1.10.7
     dotenv: 10.0.0
     express: 4.17.1
+    jest-openapi: 0.14.0
     leaked-handles: 5.2.0
     node-mocks-http: 1.10.1
     passport: 0.4.1
@@ -7834,6 +7835,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^2.0.2":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.1.0, ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -7888,6 +7903,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: b86d6cb86c69abbd8ce71ab7d4ff272660bf6d34fa9fbe770f73e54da59d531b2546692e36e2b35bbcfb11d20db774b4c09189671335185b8c799d65194e5169
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.1.0, ajv@npm:^8.4.0":
+  version: 8.6.3
+  resolution: "ajv@npm:8.6.3"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 690ffb9408415fdab43686b3f92037ba0c8362f5d0709a123ba3fb546e6ad81414455f80a2b5cc432ce924afe9864671198f022bc331a19c072d4ede152ec3ca
   languageName: node
   linkType: hard
 
@@ -10089,6 +10116,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combos@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "combos@npm:0.2.0"
+  checksum: 75f897b9c58554f80e887ee3a5afc3a095fa2fab3d3d472c9729da6d7e64fd5ee4b795d559bbd45522b0934fc19923df3f3ab2c31f850e77413d767cab26a940
+  languageName: node
+  linkType: hard
+
 "comma-separated-tokens@npm:^1.0.0":
   version: 1.0.8
   resolution: "comma-separated-tokens@npm:1.0.8"
@@ -11409,6 +11443,13 @@ __metadata:
     readable-stream: 1.1.x
     streamsearch: 0.1.2
   checksum: a6f0ce9ac5099c7ffeaec7398d711eea1dd803eb99036d0f05342e9ed46a4235a5ed0ea01ad5d6c785fdb0aae6d61d2722e6e64f9fabdfe39885f7f52eb635ee
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "diff-sequences@npm:26.6.2"
+  checksum: 79af871776ef149a7ff3345d6b1bf37fe6e81f68632aa5542787851f6f60fba19b0be22fdd1e06046f56ae7382763ccfe94a982c39ee72bd107aef435ecbc0cf
   languageName: node
   linkType: hard
 
@@ -15871,6 +15912,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "jest-diff@npm:26.6.2"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^26.6.2
+    jest-get-type: ^26.3.0
+    pretty-format: ^26.6.2
+  checksum: d00d297f31e1ac0252127089892432caa7a11c69bde29cf3bb6c7a839c8afdb95cf1fd401f9df16a4422745da2e6a5d94b428b30666a2540c38e1c5699915c2d
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^27.0.0":
   version: 27.1.0
   resolution: "jest-diff@npm:27.1.0"
@@ -15943,6 +15996,13 @@ fsevents@^1.2.7:
     jest-mock: ^27.1.1
     jest-util: ^27.2.0
   checksum: 6c2f105d4d68404af9475abaafc70fd2b6962a41416a7a1269e1195df94866e4b07ceac6a4beda11d9d73174e5f2a052a97598a3bef74a15701ad128c963a87d
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^26.3.0":
+  version: 26.3.0
+  resolution: "jest-get-type@npm:26.3.0"
+  checksum: 1cc6465ae4f5e880be22ba52fd270fa64c21994915f81b41f8f7553a7957dd8e077cc8d03035de9412e2d739f8bad6a032ebb5dab5805692a5fb9e20dd4ea666
   languageName: node
   linkType: hard
 
@@ -16038,6 +16098,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "jest-matcher-utils@npm:26.6.2"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^26.6.2
+    jest-get-type: ^26.3.0
+    pretty-format: ^26.6.2
+  checksum: 74d2165c1ac7fe98fe27cd2b5407499478e6b2fe99dd54e26d8ee5c9f5f913bdd7bdc07c7221b9b04df0c15e9be0e866ff3455b03e38cc66c480d9996d6d5405
+  languageName: node
+  linkType: hard
+
 "jest-matcher-utils@npm:^27.2.0":
   version: 27.2.0
   resolution: "jest-matcher-utils@npm:27.2.0"
@@ -16074,6 +16146,16 @@ fsevents@^1.2.7:
     "@jest/types": ^27.1.1
     "@types/node": "*"
   checksum: 7414b4eb6bacfd19fa9d9f6babb46b2ede9e49c0feecfa7b5531efadcb0fbbd6f46e95d6fb75de904b3c866824e39d163fe469195a8ce14b59b9ef9ac6df70d1
+  languageName: node
+  linkType: hard
+
+"jest-openapi@npm:0.14.0":
+  version: 0.14.0
+  resolution: "jest-openapi@npm:0.14.0"
+  dependencies:
+    jest-matcher-utils: ^26.6.2
+    openapi-validator: ^0.14.0
+  checksum: 8872c62fb80bf183f13b5e0b10d6921539a194bb771e91cfa1691e7637d80f50d703b098c2c5192992220de05d8d815d03ab8e539fd9a28d77e000e09aec8c3d
   languageName: node
   linkType: hard
 
@@ -17064,7 +17146,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.4.0, lodash.merge@npm:^4.6.2":
+"lodash.merge@npm:^4.4.0, lodash.merge@npm:^4.6.1, lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
@@ -18676,6 +18758,50 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"openapi-response-validator@npm:^9.2.0":
+  version: 9.3.0
+  resolution: "openapi-response-validator@npm:9.3.0"
+  dependencies:
+    ajv: ^8.4.0
+    openapi-types: ^9.3.0
+  checksum: 354cb846f143ab8bbcc6ed6c83a0aee64e805fe7fb2bd2de25a67d017412ee64f28ecb7d0675b970bd2a238e9d6f9f4ed74a05118c87dca75d0fca84f740ccdc
+  languageName: node
+  linkType: hard
+
+"openapi-schema-validator@npm:^9.2.0":
+  version: 9.3.0
+  resolution: "openapi-schema-validator@npm:9.3.0"
+  dependencies:
+    ajv: ^8.1.0
+    ajv-formats: ^2.0.2
+    lodash.merge: ^4.6.1
+    openapi-types: ^9.3.0
+  checksum: 33a452f7d4de5fc01b5962683e8d82415b44b69b63d64c330f9f722e03282c2251f5bc610d25318bc2fc06ceaa287a494b2e6f358867063232c023f019853360
+  languageName: node
+  linkType: hard
+
+"openapi-types@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "openapi-types@npm:9.3.0"
+  checksum: 071b002403df1f86deec10658c636a95d8f02c1469b58f5b5db02b24d4da3ce4343b6c3b30a466982205149211051d66717b497650ee097f33a19ae02fd85de0
+  languageName: node
+  linkType: hard
+
+"openapi-validator@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "openapi-validator@npm:0.14.0"
+  dependencies:
+    combos: ^0.2.0
+    fs-extra: ^9.0.0
+    js-yaml: ^4.0.0
+    openapi-response-validator: ^9.2.0
+    openapi-schema-validator: ^9.2.0
+    path-parser: ^6.1.0
+    typeof: ^1.0.0
+  checksum: 7910564721accab2083f3e93a69c4ba0e9c8b9c71e6d96c574dc7e176aed333edce55d7c92b2514c97e4ef29b481b6b682b072e7542b6e1354ff4d9b124fb5c6
+  languageName: node
+  linkType: hard
+
 "opener@npm:^1.5.2":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
@@ -19246,6 +19372,16 @@ fsevents@^1.2.7:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
+  languageName: node
+  linkType: hard
+
+"path-parser@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "path-parser@npm:6.1.0"
+  dependencies:
+    search-params: 3.0.0
+    tslib: ^1.10.0
+  checksum: fd3a2a07280002f064b53d4c90cb2d0dec1bb53c4d779aeb68b676f70e0a7bb124a3320a570c7405ceb90fd95dc696bd29d8cf8bca66146de8931a0e74a76bf3
   languageName: node
   linkType: hard
 
@@ -22142,6 +22278,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"search-params@npm:3.0.0":
+  version: 3.0.0
+  resolution: "search-params@npm:3.0.0"
+  checksum: 12bae077947eb4f80f3ab4561ee41be07a863d870f6bf2368f4ee93c6b0f874250808a2a23063883b025dc9a12e8ba344281225f6668d395685beba6fd847ce8
+  languageName: node
+  linkType: hard
+
 "section-matter@npm:^1.0.0":
   version: 1.0.0
   resolution: "section-matter@npm:1.0.0"
@@ -24208,7 +24351,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.0.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:^1.0.0, tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -24400,6 +24543,13 @@ resolve@^2.0.0-next.3:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
+  languageName: node
+  linkType: hard
+
+"typeof@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "typeof@npm:1.0.0"
+  checksum: 0d192cdaadfa230de612c6ca1e87d7294f2eded52942acd034b1b3680da06fa39a2a43b8cb31bb8ee4d1040dff0c3fcd57e3dd42434a2c7fe881d86ddd036387
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #225 

* Configure `openapi-jest` for contract testing.
* Example test for RestController.